### PR TITLE
In-memory B+-tree core

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle: LLVM
+AccessModifierOffset: -8
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignOperands: DontAlign
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: MultiLine
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 0
+CompactNamespaces: false
+ContinuationIndentWidth: 8
+IndentCaseLabels: false
+IndentPPDirectives: BeforeHash
+IndentWidth: 8
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Right
+ReflowComments: false
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 8
+UseTab: ForIndentation

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,18 @@
+# Eugene script
+build
+compile_commands.json
+
 # IDEA
 .idea
 cmake-build-debug
-build/
-out
+cmake-build-Release
+
+# CMake
+Testing
 CMakeFiles
+
+# QtCreator
+CMakeLists.txt.user
 
 # Prerequisites
 *.d

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/btree-printer"]
+	path = tools/btree-printer
+	url = https://github.com/Felerius/btree-generator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.19)
-project(bt)
+project(eugene)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
+
+add_compile_options(-Wall -Wextra -pedantic -ggdb3)
+
 
 enable_testing()
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,11 @@ add_subdirectory(src/eugene)
 
 add_subdirectory(clients)
 
-if (NOT "$ENV{BUILD_TESTS}" STREQUAL "")
+if (NOT DEFINED SKIP_BUILD_TESTS)
+	set(SKIP_BUILD_TESTS "False")
+endif()
+
+if ("${SKIP_BUILD_TESTS}" STREQUAL "False")
 	message("-- Building tests")
 	add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,13 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 enable_testing()
 include(FetchContent)
 
-# Gets populated by internal/ subdir
+# Gets populated by internal/ subdirs
 define_property(GLOBAL PROPERTY EUGENE_INTERNAL_LIBS_GLOBAL_LIST BRIEF_DOCS "internal libs of eugene" FULL_DOCS "internal libs of eugene")
 set_property(GLOBAL PROPERTY EUGENE_INTERNAL_LIBS_GLOBAL_LIST "")
 
-macro(add_internal_lib new_lib)
+macro(add_eugene_internal_lib new_lib)
     set_property(GLOBAL APPEND PROPERTY EUGENE_INTERNAL_LIBS_GLOBAL_LIST "${new_lib}")
-endmacro(add_internal_lib)
+endmacro(add_eugene_internal_lib)
 
 add_subdirectory(src/external)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,17 @@ project(eugene)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/build")
 
-add_compile_options(-Wall -Wextra -pedantic -ggdb3)
+add_compile_options(
+	-Wall
+	-Wno-comment
+	-Wextra
+	-Werror
+	-pedantic
+	-ggdb3
+	-fdiagnostics-color
+	-fconcepts-diagnostics-depth=2)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 enable_testing()
 include(FetchContent)
@@ -27,4 +36,7 @@ add_subdirectory(src/eugene)
 
 add_subdirectory(clients)
 
-add_subdirectory(tests)
+if (NOT "$ENV{BUILD_TESTS}" STREQUAL "")
+	message("-- Building tests")
+	add_subdirectory(tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# eugene
-Search engine prototype based on elasticsearch.

--- a/src/internal/CMakeLists.txt
+++ b/src/internal/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(BTREE_DIR "btree/")
-set(BTREE_SOURCES Btree.h)
+set(BTREE_SOURCES Btree.h BtreePrinter.h)
 list(TRANSFORM BTREE_SOURCES PREPEND ${BTREE_DIR})
 
 add_library(btree ${BTREE_SOURCES})

--- a/src/internal/CMakeLists.txt
+++ b/src/internal/CMakeLists.txt
@@ -1,20 +1,13 @@
-set(BTREE_DIR "btree/")
-set(BTREE_SOURCES Btree.h BtreePrinter.h)
-list(TRANSFORM BTREE_SOURCES PREPEND ${BTREE_DIR})
+set(BTREE_SOURCES
+        btree/Btree.h
+        btree/BtreePrinter.h)
 
-add_library(btree ${BTREE_SOURCES})
-set_target_properties(btree PROPERTIES LINKER_LANGUAGE CXX)
-target_include_directories(btree PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
-target_link_libraries(btree PRIVATE pthread expected)
-
-get_property(EUGENE_INTERNAL_LIBS GLOBAL PROPERTY EUGENE_INTERNAL_LIBS_PROPERTY)
-add_internal_lib(btree)
-
-set(STORAGE_DIR "storage/")
-set(STORAGE_SOURCES Storage.h)
-list(TRANSFORM STORAGE_SOURCES PREPEND ${STORAGE_DIR})
+set(STORAGE_SOURCES Storage.h "${BTREE_SOURCE}")
+list(TRANSFORM STORAGE_SOURCES PREPEND "storage/")
 
 add_library(storage "${STORAGE_SOURCES}")
+add_eugene_internal_lib(storage)
+
 set_target_properties(storage PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(storage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
-add_internal_lib(storage)
+target_link_libraries(storage PRIVATE pthread expected)

--- a/src/internal/CMakeLists.txt
+++ b/src/internal/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(BTREE_DIR "btree/")
+set(BTREE_SOURCES Btree.h)
+list(TRANSFORM BTREE_SOURCES PREPEND ${BTREE_DIR})
+
+add_library(btree ${BTREE_SOURCES})
+set_target_properties(btree PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(btree PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
+target_link_libraries(btree PRIVATE pthread expected)
+
+get_property(EUGENE_INTERNAL_LIBS GLOBAL PROPERTY EUGENE_INTERNAL_LIBS_PROPERTY)
+add_internal_lib(btree)
+
+set(STORAGE_DIR "storage/")
+set(STORAGE_SOURCES Storage.h)
+list(TRANSFORM STORAGE_SOURCES PREPEND ${STORAGE_DIR})
+
+add_library(storage "${STORAGE_SOURCES}")
+set_target_properties(storage PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(storage PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
+add_internal_lib(storage)

--- a/src/internal/btree/Btree.h
+++ b/src/internal/btree/Btree.h
@@ -2,762 +2,754 @@
 
 #include <internal/storage/Storage.h>
 
-#include <algorithm>     // std::min
-#include <array>         // std::array
-#include <cassert>       // assert
-#include <memory>        // std::unique_ptr
-#include <optional>      // std::nullopt_t
-#include <tuple>         // std::tie
-#include <unordered_map> // std::unordered_map
-#include <utility>       // std::move, std::pair
-#include <variant>       // std::variant
+#include <algorithm>    // std::min
+#include <array>        // std::array
+#include <cassert>      // assert
+#include <memory>       // std::unique_ptr
+#include <optional>     // std::nullopt_t
+#include <tuple>        // std::tie
+#include <unordered_map>// std::unordered_map
+#include <utility>      // std::move, std::pair
+#include <variant>      // std::variant
 
-template <typename T> consteval bool PowerOf2(T num) {
-  return (num & (num - 1)) == 0;
+template<typename T>
+consteval bool PowerOf2(T num) {
+	return (num & (num - 1)) == 0;
 }
 
 #define unsafe_ /* unsafe function */
 
-template <typename T>
+template<typename T>
 using optional_ref = std::optional<std::reference_wrapper<T>>;
 
-template <typename T>
+template<typename T>
 using optional_cref = std::optional<std::reference_wrapper<const T>>;
 
 namespace internal::btree {
 
-template <typename Config>
+template<typename Config>
 concept BtreeConfig = requires(Config conf) {
-  typename Config::Key;
-  typename Config::KeyRef;
-  typename Config::Val;
-  typename Config::StorageDev;
+	typename Config::Key;
+	typename Config::KeyRef;
+	typename Config::Val;
+	typename Config::StorageDev;
 
-  requires std::convertible_to<decltype(conf.ApplyCompression), bool>;
-  requires storage::StorageDevice<typename Config::StorageDev>;
-  requires std::unsigned_integral<decltype(conf.BtreeNodeSize)>;
+	requires std::convertible_to<decltype(conf.ApplyCompression), bool>;
+	requires storage::StorageDevice<typename Config::StorageDev>;
+	requires std::unsigned_integral<decltype(conf.BtreeNodeSize)>;
 }
 &&PowerOf2(Config::BtreeNodeSize);
 
 struct DefaultBtreeConfig {
-  using Key = uint32_t;
-  using KeyRef = Key;
-  using Val = uint32_t;
-  using StorageDev = storage::DefaultStorageDev;
-  static constexpr unsigned BtreeNodeSize = 1 << 10;
-  static constexpr bool ApplyCompression = false;
+	using Key = uint32_t;
+	using KeyRef = Key;
+	using Val = uint32_t;
+	using StorageDev = storage::DefaultStorageDev;
+	static constexpr unsigned BtreeNodeSize = 1 << 10;
+	static constexpr bool ApplyCompression = false;
 };
 
 namespace util {
-template <BtreeConfig Config> class BtreeYAMLPrinter;
+template<BtreeConfig Config>
+class BtreeYAMLPrinter;
 }
 
-template <typename Config = DefaultBtreeConfig>
+template<typename Config = DefaultBtreeConfig>
 requires BtreeConfig<Config>
 class Btree final {
 private:
-  using Position = storage::Position;
+	using Position = storage::Position;
 
-  using Key = typename Config::Key;
-  using KeyRef = typename Config::KeyRef;
-  using Val = typename Config::Val;
-  using Storage = typename Config::StorageDev;
+	using Key = typename Config::Key;
+	using KeyRef = typename Config::KeyRef;
+	using Val = typename Config::Val;
+	using Storage = typename Config::StorageDev;
 
-  static constexpr bool ApplyCompression = Config::ApplyCompression;
-  static constexpr uint32_t BtreeNodeSize = Config::BtreeNodeSize;
-
-public:
-  class Node;
-
-  friend Node;
-
-  class Iterator;
-
-  friend Iterator;
-
-  friend util::BtreeYAMLPrinter<Config>;
-
-public: // Constructors
-  Btree() = default;
-
-  template <typename... Args>
-  explicit Btree(Args &&...args) noexcept
-      : m_storage(std::forward<Args>(args)...) {}
+	static constexpr bool ApplyCompression = Config::ApplyCompression;
+	static constexpr uint32_t BtreeNodeSize = Config::BtreeNodeSize;
 
 public:
-  ~Btree() noexcept = default;
+	class Node;
 
-  bool operator<=>(const Btree &rhs) const noexcept {
-    return m_root.operator<=>(rhs);
-  }
+	friend Node;
 
-public: // API
-  Iterator begin() noexcept { return Iterator::begin(*this); }
+	class Iterator;
 
-  Iterator end() noexcept { return Iterator::end(*this); }
+	friend Iterator;
 
-  Iterator insert(const Key &key, const Val &val) noexcept {
-    Node &cur = m_root;
-    while (true) {
-      auto [it, next] = cur.find(key);
-      if (next)
-        ++it;
-      if (cur.is_leaf())
-        return cur.insert(key, val, it);
-      if (it == cur.end())
-        break;
-      cur = *it;
-    }
+	friend util::BtreeYAMLPrinter<Config>;
 
-    return end();
-  }
+public:// Constructors
+	Btree() = default;
 
-  std::optional<Iterator> find(const Key &target) noexcept {
-    Node &cur = const_cast<Node &>(m_root);
-    while (true) {
-      auto [it, next] = cur.find(target);
-      if (cur.is_leaf()) {
-        if (!next)
-          break;
-        return std::make_optional(it);
-      }
+	template<typename... Args>
+	explicit Btree(Args &&...args) noexcept
+	    : m_storage(std::forward<Args>(args)...) {}
 
-      if (next)
-        ++it;
+public:
+	~Btree() noexcept = default;
 
-      cur = *it;
-    }
+	bool operator<=>(const Btree &rhs) const noexcept {
+		return m_root.operator<=>(rhs);
+	}
 
-    return std::nullopt;
-  }
+public:// API
+	Iterator begin() noexcept { return Iterator::begin(*this); }
 
-  optional_cref<Val> get(const Key &target) noexcept {
-    auto maybe_it = find(target);
-    if (!maybe_it)
-      return std::nullopt;
+	Iterator end() noexcept { return Iterator::end(*this); }
 
-    auto it = maybe_it.value();
-    if (it == end())
-      return std::nullopt;
+	Iterator insert(const Key &key, const Val &val) noexcept {
+		Node &cur = m_root;
+		while (true) {
+			auto [it, next] = cur.find(key);
+			if (next)
+				++it;
+			if (cur.is_leaf())
+				return cur.insert(key, val, it);
+			if (it == cur.end())
+				break;
+			cur = *it;
+		}
 
-    auto maybe_val = it.val();
-    return maybe_val;
-  }
+		return end();
+	}
 
-  optional_cref<Val> operator[](const Key &target) noexcept {
-    return get(target);
-  }
+	std::optional<Iterator> find(const Key &target) noexcept {
+		Node &cur = const_cast<Node &>(m_root);
+		while (true) {
+			auto [it, next] = cur.find(target);
+			if (cur.is_leaf()) {
+				if (!next)
+					break;
+				return std::make_optional(it);
+			}
 
-  void erase(const Key &target) noexcept {
-    (void)target;
-    // Function is not yet implemented
-    assert(false);
-  }
+			if (next)
+				++it;
 
-public: // Getters
-  const Node &root() const noexcept { return m_root; }
+			cur = *it;
+		}
 
-  Node &root() noexcept { return m_root; }
+		return std::nullopt;
+	}
+
+	optional_cref<Val> get(const Key &target) noexcept {
+		auto maybe_it = find(target);
+		if (!maybe_it)
+			return std::nullopt;
+
+		auto it = maybe_it.value();
+		if (it == end())
+			return std::nullopt;
+
+		auto maybe_val = it.val();
+		return maybe_val;
+	}
+
+	optional_cref<Val> operator[](const Key &target) noexcept {
+		return get(target);
+	}
+
+	void erase(const Key &target) noexcept {
+		(void) target;
+		// Function is not yet implemented
+		assert(false);
+	}
+
+public:// Getters
+	const Node &root() const noexcept { return m_root; }
+
+	Node &root() noexcept { return m_root; }
 
 private:
-  Storage m_storage;
-  Node m_root = Node::Root(*this, Node::Type::Leaf);
+	Storage m_storage;
+	Node m_root = Node::Root(*this, Node::Type::Leaf);
 };
 
-template <BtreeConfig Config> class Btree<Config>::Node final {
+template<BtreeConfig Config>
+class Btree<Config>::Node final {
 private:
-  using Bt = Btree<Config>;
-  friend Bt::Iterator;
+	using Bt = Btree<Config>;
+	friend Bt::Iterator;
 
 public:
-  enum class Type { Branch, Leaf };
+	enum class Type { Branch,
+		          Leaf };
 
-  struct Header {
-    storage::Position self_{storage::PositionPoison};
-    storage::Position prev_{storage::PositionPoison};
-    storage::Position next_{storage::PositionPoison};
-    storage::Position parent_{storage::PositionPoison};
-    Type type_;
+	struct Header {
+		storage::Position self_{storage::PositionPoison};
+		storage::Position prev_{storage::PositionPoison};
+		storage::Position next_{storage::PositionPoison};
+		storage::Position parent_{storage::PositionPoison};
+		Type type_;
 
-    explicit Header(Type t) : type_{t} {}
+		explicit Header(Type t) : type_{t} {}
 
-    explicit Header(std::nullopt_t) {}
+		explicit Header(std::nullopt_t) {}
 
-    Header(const Header &) = default;
+		Header(const Header &) = default;
 
-    bool operator<=>(const Header &) const noexcept = default;
-  };
+		bool operator<=>(const Header &) const noexcept = default;
+	};
 
-  struct MemHeader {
-    optional_ref<Node> prev_{};
-    optional_ref<Node> next_{};
-    optional_ref<Node> parent_{};
-    Type type_;
+	struct MemHeader {
+		optional_ref<Node> prev_{};
+		optional_ref<Node> next_{};
+		optional_ref<Node> parent_{};
+		Type type_;
 
-    explicit MemHeader(Type t) : type_{t} {}
+		explicit MemHeader(Type t) : type_{t} {}
 
-    explicit MemHeader(std::nullopt_t) {}
+		explicit MemHeader(std::nullopt_t) {}
 
-    MemHeader(const MemHeader &) = default;
+		MemHeader(const MemHeader &) = default;
 
-    bool operator<=>(const MemHeader &) const noexcept = default;
-  };
-
-private:
-  static consteval long _calc_num_records(auto metasize) {
-    const auto leaf_size = metasize / (sizeof(Key) + sizeof(Val));
-    const auto branch_size =
-        (metasize - sizeof(Position)) / (sizeof(Position) + sizeof(KeyRef));
-    return std::min(leaf_size, branch_size);
-  }
-
-  enum {
-    NodeLimit = Config::BtreeNodeSize,
-    MetaSize = NodeLimit - sizeof(Header),
-    NumRecords = _calc_num_records(MetaSize),
-    NumLinks = NumRecords + 1,
-  };
-
-  static_assert(NodeLimit > 0, "Node limit has to be a positive number.");
-  static_assert(PowerOf2(NodeLimit), "Node limit has to be a power of 2.");
-  static_assert(NumLinks == NumRecords + 1,
-                "Node links must be one more than the number of records.");
-  static_assert(NumLinks > 2, "Node links must be more than 2.");
-
-public:
-  using LeafKeyRecords = std::array<Key, NumRecords>;
-  using LeafValRecords = std::array<Val, NumRecords>;
-  using BranchRefs = std::array<KeyRef, NumRecords>;
-  using BranchLinks = std::array<Position, NumLinks>;
-
-  struct LeafMeta {
-    LeafKeyRecords keys_;
-    LeafValRecords vals_;
-
-    bool operator<=>(const LeafMeta &) const noexcept = default;
-  };
-
-  struct BranchMeta {
-    BranchRefs refs_;
-    BranchLinks links_;
-
-    bool operator<=>(const BranchMeta &) const noexcept = default;
-  };
-
-public:
-  static consteval auto records_() { return Node::NumRecords; }
-
-  static consteval auto links_() { return Node::NumLinks; }
+		bool operator<=>(const MemHeader &) const noexcept = default;
+	};
 
 private:
-  // Maps BranchMeta::links_ of type Position to actual in-memory Node *
-  static auto &LinkToPtrMap() noexcept {
-    static std::unordered_map<Position, Node *> mapper_{};
-    return mapper_;
-  }
+	static consteval long _calc_num_records(auto metasize) {
+		const auto leaf_size = metasize / (sizeof(Key) + sizeof(Val));
+		const auto branch_size =
+		        (metasize - sizeof(Position)) / (sizeof(Position) + sizeof(KeyRef));
+		return std::min(leaf_size, branch_size);
+	}
 
-public: // Getters
-  [[nodiscard]] bool is_branch() const noexcept {
-    if (m_header && m_header.value().type_ == Type::Branch)
-      return true;
-    if (m_mem && m_mem.value().type_ == Type::Branch)
-      return true;
-    return false;
-  }
+	enum {
+		NodeLimit = Config::BtreeNodeSize,
+		MetaSize = NodeLimit - sizeof(Header),
+		NumRecords = _calc_num_records(MetaSize),
+		NumLinks = NumRecords + 1,
+	};
 
-  [[nodiscard]] bool is_leaf() const noexcept { return !is_branch(); }
-
-  [[nodiscard]] bool is_full() const noexcept {
-    assert(m_numfilled <= NumRecords);
-    return m_numfilled == NumRecords;
-  }
-
-  [[nodiscard]] bool is_ok() const noexcept { return m_numfilled < NumRecords; }
-
-  [[nodiscard]] bool is_empty() const noexcept { return !m_numfilled; }
-
-  [[nodiscard]] bool is_rightmost() const noexcept {
-    if (m_mem.has_value()) {
-      const auto &mem = m_mem.value();
-      return !mem.next_.has_value();
-    }
-    // if (const auto &h : m_header.value(); h.has_value()) ;
-    // TODO: Fetch
-    return false;
-  }
-
-  [[nodiscard]] bool is_leftmost() const noexcept {
-    if (m_mem.has_value()) {
-      const auto &mem = m_mem.value();
-      return !mem.prev_.has_value();
-    }
-
-    // if (const auto &h : m_header.value(); h.has_value()) ;
-    // TODO: Fetch
-    return false;
-  }
-
-  [[nodiscard]] bool is_root() const noexcept {
-    if (m_mem.has_value()) {
-      const auto &mem = m_mem.value();
-      return !mem.parent_.has_value();
-    }
-    // if (const auto &h : m_header.value(); h.has_value()) ;
-    // TODO: Fetch
-    return false;
-  }
-
-  [[nodiscard]] optional_cref<Header> header() const noexcept {
-    if (!m_header.has_value())
-      return std::nullopt;
-    return std::make_optional(std::cref(m_header.value()));
-  }
-
-  [[nodiscard]] optional_cref<MemHeader> memheader() const noexcept {
-    if (!m_mem.has_value())
-      return std::nullopt;
-    return std::make_optional(std::cref(m_mem.value()));
-  }
-
-  [[nodiscard]] LeafMeta &leaf() { return std::get<LeafMeta>(m_meta); }
-
-  [[nodiscard]] BranchMeta &branch() { return std::get<BranchMeta>(m_meta); }
-
-  [[nodiscard]] const LeafMeta &leaf() unsafe_ const {
-    return std::get<LeafMeta>(m_meta);
-  }
-
-  [[nodiscard]] const BranchMeta &branch() unsafe_ const {
-    return std::get<BranchMeta>(m_meta);
-  }
-
-  [[nodiscard]] auto range() const noexcept {
-    if (is_branch())
-      return std::make_pair(branch().refs_.begin(), branch().refs_.end());
-    return std::make_pair(leaf().keys_.begin(), leaf().keys_.end());
-  }
-
-  [[nodiscard]] const Key *raw() const noexcept {
-    if (is_branch())
-      return branch().refs_.data();
-    return leaf().keys_.data();
-  }
-
-  [[nodiscard]] const Key &at(long idx) const noexcept {
-    assert(m_numfilled > idx);
-    const auto &key_at_idx = raw()[idx];
-    return key_at_idx;
-  }
-
-  [[nodiscard]] const Key &first() const noexcept { return at(0); }
-
-  [[nodiscard]] const Key &last() const noexcept { return at(m_numfilled - 1); }
-
-  [[nodiscard]] Iterator begin() noexcept {
-    return Iterator{*this, 0, *m_tree};
-  }
-        
-        [[nodiscard]] Iterator begin() const noexcept {
-                return Iterator{*this, 0, *m_tree};
-        }
-
-  [[nodiscard]] Iterator end() noexcept {
-    return Iterator{*this, m_numfilled, *m_tree};
-  }
-        
-        [[nodiscard]] Iterator end() const noexcept {
-                return Iterator{*this, m_numfilled, *m_tree};
-        }
-
-  [[nodiscard]] std::optional<storage::Position> self() const noexcept {
-    if (m_header)
-      return m_header.value().self_;
-    return std::nullopt;
-  }
-
-  [[nodiscard]] std::optional<storage::Position> parent() const noexcept {
-    if (m_header)
-      return m_header.value().parent_;
-    return std::nullopt;
-  }
-
-  [[nodiscard]] optional_cref<Node> memparent() const noexcept {
-    if (m_mem)
-      return m_mem.value().parent_;
-    return std::nullopt;
-  }
-
-  void set_numfilled(long numfilled) noexcept { m_numfilled = numfilled; }
-
-  [[nodiscard]] long numfilled() const noexcept { return m_numfilled; }
-
-  void set_prev(Node *const mprev,
-                std::optional<storage::Position> prev = {}) noexcept {
-    if (m_mem)
-      m_mem.value().prev_.emplace(std::ref(*mprev));
-
-    if (m_header && prev)
-      m_header.value().prev_ = prev.value();
-  }
-
-  void set_next(Node *const mnext,
-                std::optional<storage::Position> next = {}) noexcept {
-    if (m_mem)
-      m_mem.value().next_.emplace(std::ref(*mnext));
-
-    if (m_header && next)
-      m_header.value().next_ = next.value();
-  }
-
-public: // Constructors
-  constexpr explicit Node(Bt &bt, std::optional<MemHeader> memheader = {},
-                          std::optional<Header> header = {})
-      : m_header{std::move(header)}, m_mem{std::move(memheader)}, m_tree{&bt} {
-    if (is_branch())
-      m_meta = BranchMeta{};
-    else
-      m_meta = LeafMeta{};
-  }
-
-  Node(const Node &) = default;
-
-  static constexpr Node InMemoryNode(Bt &bt, MemHeader &&memheader) {
-    return Node{bt, std::make_optional(memheader)};
-  }
-
-  static constexpr Node StoredNode(Bt &bt, Header &&header) {
-    return Node{bt, std::nullopt, std::make_optional(header)};
-  }
-
-  static constexpr Node Root(Bt &bt, Type type) {
-    return Node{bt, MemHeader{type}};
-  }
+	static_assert(NodeLimit > 0, "Node limit has to be a positive number.");
+	static_assert(PowerOf2(NodeLimit), "Node limit has to be a power of 2.");
+	static_assert(NumLinks == NumRecords + 1,
+	              "Node links must be one more than the number of records.");
+	static_assert(NumLinks > 2, "Node links must be more than 2.");
 
 public:
-  ~Node() noexcept = default;
+	using LeafKeyRecords = std::array<Key, NumRecords>;
+	using LeafValRecords = std::array<Val, NumRecords>;
+	using BranchRefs = std::array<KeyRef, NumRecords>;
+	using BranchLinks = std::array<Position, NumLinks>;
 
-  Node &operator=(const Node &rhs) noexcept = default;
+	struct LeafMeta {
+		LeafKeyRecords keys_;
+		LeafValRecords vals_;
 
-  bool operator<=>(const Node &rhs) const noexcept = default;
+		bool operator<=>(const LeafMeta &) const noexcept = default;
+	};
 
-private: // Helpers
-  Iterator spill_right(LeafMeta &asleaf, long middle_idx) noexcept {
-    const auto pivot_idx = middle_idx + 1;
-    auto sibling_ptr = std::make_shared<Node>(*m_tree, m_mem, m_header);
-    Node &sibling = *sibling_ptr;
-    auto &sleaf = sibling.leaf();
+	struct BranchMeta {
+		BranchRefs refs_;
+		BranchLinks links_;
 
-    std::copy(asleaf.keys_.begin() + pivot_idx, asleaf.keys_.end(),
-              sleaf.keys_.begin());
-    std::copy(asleaf.vals_.begin() + pivot_idx, asleaf.vals_.end(),
-              sleaf.vals_.begin());
+		bool operator<=>(const BranchMeta &) const noexcept = default;
+	};
 
-    sibling.set_prev(this, self());
-    set_next(sibling_ptr.get(), sibling.self());
+public:
+	static consteval auto records_() { return Node::NumRecords; }
 
-    sibling.set_numfilled(NumRecords - pivot_idx);
-    set_numfilled(middle_idx);
-    return Iterator{*this, middle_idx, *m_tree};
-  }
+	static consteval auto links_() { return Node::NumLinks; }
 
-  Iterator raise_to_parent(Iterator it) noexcept {
-    [[maybe_unused]] Node &node = it.node_mut();
+public:
+	static Node *fetch_node(const Position pos) noexcept {
+		static std::unordered_map<Position, Node *> cache{};
+		if (!cache.contains(pos)) {
+			// Perform disk-io to get the Node value in "cache"
+		}
 
-    return it;
-  }
+		return cache.at(pos);
+	}
 
-public: // API
-  /// @brief This insert routine relies on us knowing where exactly the
-  /// data should reside in it -- i.e `it`.
-  Iterator insert(const Key &key, const Val &val, Iterator it) {
-    const auto idx = it.index();
-    auto &as_leaf = leaf();
-    as_leaf.keys_[idx] = key;
-    as_leaf.vals_[idx] = val;
-    ++m_numfilled;
+public:// Getters
+	[[nodiscard]] bool is_branch() const noexcept {
+		if (m_header && m_header.value().type_ == Type::Branch)
+			return true;
+		if (m_mem && m_mem.value().type_ == Type::Branch)
+			return true;
+		return false;
+	}
 
-    if (is_ok())
-      return it;
+	[[nodiscard]] bool is_leaf() const noexcept { return !is_branch(); }
 
-    // Not ok. Perform rebalancing policy.
-    // That is - regular B-tree for now.
+	[[nodiscard]] bool is_full() const noexcept {
+		assert(m_numfilled <= NumRecords);
+		return m_numfilled == NumRecords;
+	}
 
-    const auto middle_idx = (NumRecords + 1) / 2;
-    Iterator pivot = spill_right(leaf(), middle_idx);
-    Iterator pos = raise_to_parent(pivot);
-    return pos;
-  }
+	[[nodiscard]] bool is_ok() const noexcept { return m_numfilled < NumRecords; }
 
-  std::pair<Iterator, bool> find(const Key &target) noexcept {
-    auto [lo, _] = range();
-    auto hi = lo + m_numfilled;
-    const auto beginning = lo;
+	[[nodiscard]] bool is_empty() const noexcept { return !m_numfilled; }
 
-    while (lo < hi) {
-      auto mid = lo;
-      std::advance(mid, std::distance(lo, hi) / 2);
-      if (target > *mid)
-        lo = mid + 1;
-      else
-        hi = mid;
-    }
+	[[nodiscard]] bool is_rightmost() const noexcept {
+		if (m_mem.has_value()) {
+			const auto &mem = m_mem.value();
+			return !mem.next_.has_value();
+		}
+		// if (const auto &h : m_header.value(); h.has_value()) ;
+		// TODO: Fetch
+		return false;
+	}
 
-    long idx = std::distance(beginning, hi);
-    auto it = Iterator{*this, idx, *m_tree};
-    return std::make_pair(it, *hi == target && m_numfilled > 0);
-  }
+	[[nodiscard]] bool is_leftmost() const noexcept {
+		if (m_mem.has_value()) {
+			const auto &mem = m_mem.value();
+			return !mem.prev_.has_value();
+		}
+
+		// if (const auto &h : m_header.value(); h.has_value()) ;
+		// TODO: Fetch
+		return false;
+	}
+
+	[[nodiscard]] bool is_root() const noexcept {
+		if (m_mem.has_value()) {
+			const auto &mem = m_mem.value();
+			return !mem.parent_.has_value();
+		}
+		// if (const auto &h : m_header.value(); h.has_value()) ;
+		// TODO: Fetch
+		return false;
+	}
+
+	[[nodiscard]] optional_cref<Header> header() const noexcept {
+		if (!m_header.has_value())
+			return std::nullopt;
+		return std::make_optional(std::cref(m_header.value()));
+	}
+
+	[[nodiscard]] optional_cref<MemHeader> memheader() const noexcept {
+		if (!m_mem.has_value())
+			return std::nullopt;
+		return std::make_optional(std::cref(m_mem.value()));
+	}
+
+	[[nodiscard]] LeafMeta &leaf() { return std::get<LeafMeta>(m_meta); }
+
+	[[nodiscard]] BranchMeta &branch() { return std::get<BranchMeta>(m_meta); }
+
+	[[nodiscard]] const LeafMeta &leaf() unsafe_ const {
+		return std::get<LeafMeta>(m_meta);
+	}
+
+	[[nodiscard]] const BranchMeta &branch() unsafe_ const {
+		return std::get<BranchMeta>(m_meta);
+	}
+
+	[[nodiscard]] auto range() const noexcept {
+		if (is_branch())
+			return std::make_pair(branch().refs_.begin(), branch().refs_.end());
+		return std::make_pair(leaf().keys_.begin(), leaf().keys_.end());
+	}
+
+	[[nodiscard]] const Key *raw() const noexcept {
+		if (is_branch())
+			return branch().refs_.data();
+		return leaf().keys_.data();
+	}
+
+	[[nodiscard]] const Key &at(long idx) const noexcept {
+		assert(m_numfilled > idx);
+		const auto &key_at_idx = raw()[idx];
+		return key_at_idx;
+	}
+
+	[[nodiscard]] const Key &first() const noexcept { return at(0); }
+
+	[[nodiscard]] const Key &last() const noexcept { return at(m_numfilled - 1); }
+
+	[[nodiscard]] Iterator begin() noexcept {
+		return Iterator{*this, 0, *m_tree};
+	}
+
+	[[nodiscard]] Iterator begin() const noexcept {
+		return Iterator{*this, 0, *m_tree};
+	}
+
+	[[nodiscard]] Iterator end() noexcept {
+		return Iterator{*this, m_numfilled, *m_tree};
+	}
+
+	[[nodiscard]] Iterator end() const noexcept {
+		return Iterator{*this, m_numfilled, *m_tree};
+	}
+
+	[[nodiscard]] std::optional<storage::Position> self() const noexcept {
+		if (m_header)
+			return m_header.value().self_;
+		return std::nullopt;
+	}
+
+	[[nodiscard]] std::optional<storage::Position> parent() const noexcept {
+		if (m_header)
+			return m_header.value().parent_;
+		return std::nullopt;
+	}
+
+	[[nodiscard]] optional_cref<Node> memparent() const noexcept {
+		if (m_mem)
+			return m_mem.value().parent_;
+		return std::nullopt;
+	}
+
+	void set_numfilled(long numfilled) noexcept { m_numfilled = numfilled; }
+
+	[[nodiscard]] long numfilled() const noexcept { return m_numfilled; }
+
+	void set_prev(Node *const mprev,
+	              std::optional<storage::Position> prev = {}) noexcept {
+		if (m_mem)
+			m_mem.value().prev_.emplace(std::ref(*mprev));
+
+		if (m_header && prev)
+			m_header.value().prev_ = prev.value();
+	}
+
+	void set_next(Node *const mnext,
+	              std::optional<storage::Position> next = {}) noexcept {
+		if (m_mem)
+			m_mem.value().next_.emplace(std::ref(*mnext));
+
+		if (m_header && next)
+			m_header.value().next_ = next.value();
+	}
+
+public:// Constructors
+	constexpr explicit Node(Bt &bt, std::optional<MemHeader> memheader = {},
+	                        std::optional<Header> header = {})
+	    : m_header{std::move(header)}, m_mem{std::move(memheader)}, m_tree{&bt} {
+		if (is_branch())
+			m_meta = BranchMeta{};
+		else
+			m_meta = LeafMeta{};
+	}
+
+	Node(const Node &) = default;
+
+	static constexpr Node InMemoryNode(Bt &bt, MemHeader &&memheader) {
+		return Node{bt, std::make_optional(memheader)};
+	}
+
+	static constexpr Node StoredNode(Bt &bt, Header &&header) {
+		return Node{bt, std::nullopt, std::make_optional(header)};
+	}
+
+	static constexpr Node Root(Bt &bt, Type type) {
+		return Node{bt, MemHeader{type}};
+	}
+
+public:
+	~Node() noexcept = default;
+
+	Node &operator=(const Node &rhs) noexcept = default;
+
+	bool operator<=>(const Node &rhs) const noexcept = default;
+
+private:// Helpers
+	Iterator spill_right(LeafMeta &asleaf, long middle_idx) noexcept {
+		const auto pivot_idx = middle_idx + 1;
+		auto sibling_ptr = std::make_shared<Node>(*m_tree, m_mem, m_header);
+		Node &sibling = *sibling_ptr;
+		auto &sleaf = sibling.leaf();
+
+		std::copy(asleaf.keys_.begin() + pivot_idx, asleaf.keys_.end(),
+		          sleaf.keys_.begin());
+		std::copy(asleaf.vals_.begin() + pivot_idx, asleaf.vals_.end(),
+		          sleaf.vals_.begin());
+
+		sibling.set_prev(this, self());
+		set_next(sibling_ptr.get(), sibling.self());
+
+		sibling.set_numfilled(NumRecords - pivot_idx);
+		set_numfilled(middle_idx);
+		return Iterator{*this, middle_idx, *m_tree};
+	}
+
+	Iterator raise_to_parent(Iterator it) noexcept {
+		[[maybe_unused]] Node &node = it.node_mut();
+
+		return it;
+	}
+
+public:// API
+	/// @brief This insert routine relies on us knowing where exactly the
+	/// data should reside in it -- i.e `it`.
+	Iterator insert(const Key &key, const Val &val, Iterator it) {
+		const auto idx = it.index();
+		auto &as_leaf = leaf();
+		as_leaf.keys_[idx] = key;
+		as_leaf.vals_[idx] = val;
+		++m_numfilled;
+
+		if (is_ok())
+			return it;
+
+		// Not ok. Perform rebalancing policy.
+		// That is - regular B-tree for now.
+
+		const auto middle_idx = (NumRecords + 1) / 2;
+		Iterator pivot = spill_right(leaf(), middle_idx);
+		Iterator pos = raise_to_parent(pivot);
+		return pos;
+	}
+
+	std::pair<Iterator, bool> find(const Key &target) noexcept {
+		auto [lo, _] = range();
+		auto hi = lo + m_numfilled;
+		const auto beginning = lo;
+
+		while (lo < hi) {
+			auto mid = lo;
+			std::advance(mid, std::distance(lo, hi) / 2);
+			if (target > *mid)
+				lo = mid + 1;
+			else
+				hi = mid;
+		}
+
+		long idx = std::distance(beginning, hi);
+		auto it = Iterator{*this, idx, *m_tree};
+		return std::make_pair(it, *hi == target && m_numfilled > 0);
+	}
 
 private:
-  std::optional<Header> m_header{std::nullopt};
-  std::optional<MemHeader> m_mem{std::nullopt};
-  Bt *m_tree;
+	std::optional<Header> m_header{std::nullopt};
+	std::optional<MemHeader> m_mem{std::nullopt};
+	Bt *m_tree;
 
-  std::variant<LeafMeta, BranchMeta> m_meta;
-  long m_numfilled{0};
+	std::variant<LeafMeta, BranchMeta> m_meta;
+	long m_numfilled{0};
 };
 
-template <BtreeConfig Config> class Btree<Config>::Iterator final {
-public: // Iterator traits
-  using difference_type = long;
-  using value_type = Node;
-  using pointer = Node *;
-  using reference = Node &;
-  using iterator_category = std::bidirectional_iterator_tag;
+template<BtreeConfig Config>
+class Btree<Config>::Iterator final {
+public:// Iterator traits
+	using difference_type = long;
+	using value_type = Node;
+	using pointer = Node *;
+	using reference = Node &;
+	using iterator_category = std::bidirectional_iterator_tag;
 
 private:
-  using Val = Config::Val;
-  using Key = Config::Key;
+	using Val = Config::Val;
+	using Key = Config::Key;
 
-public: // Constructor
-  Iterator() = default;
+public:// Constructor
+	Iterator() = default;
 
-  Iterator(const Iterator &) noexcept = default;
+	Iterator(const Iterator &) noexcept = default;
 
-  /// Tree::begin iterator
-  explicit Iterator(Btree &tree) : m_node{nullptr}, m_index{0}, m_tree{&tree} {
-    Node &cur = tree.root();
-    while (cur.is_branch()) {
-      const auto &branch_meta = cur.branch();
+	/// Tree::begin iterator
+	explicit Iterator(Btree &tree) : m_node{nullptr}, m_index{0}, m_tree{&tree} {
+		Node &cur = tree.root();
+		while (cur.is_branch()) {
+			const auto &branch_meta = cur.branch();
 
-      assert(cur.numfilled() > 0);
-      const Position last_link = branch_meta.links_[0];
+			assert(cur.numfilled() > 0);
+			const Position last_link = branch_meta.links_[0];
 
-      if (auto ptr = Node::LinkToPtrMap().at(last_link); ptr) {
-        cur = *ptr;
-        continue;
-      }
+			cur = *Node::fetch_node(last_link);
+		}
 
-      // TODO:
-      // Fetch Node from media and put it in memory
-      // As of now this path should be avoided.
-      assert(false);
-    }
+		m_node = &cur;
+	}
 
-    m_node = &cur;
-  }
+	/// Iterator to a specific location in the tree
+	Iterator(Node &node, long index, Btree &tree)
+	    : m_node{&node}, m_index{index}, m_tree{&tree} {}
 
-  /// Iterator to a specific location in the tree
-  Iterator(Node &node, long index, Btree &tree)
-      : m_node{&node}, m_index{index}, m_tree{&tree} {}
+	static Iterator begin(Btree &tree) { return Iterator{tree}; }
 
-  static Iterator begin(Btree &tree) { return Iterator{tree}; }
+	static Iterator end(Btree &tree) {
+		Node &cur = tree.root();
+		while (cur.is_branch()) {
+			const auto &branch_meta = cur.branch();
 
-  static Iterator end(Btree &tree) {
-    Node &cur = tree.root();
-    while (cur.is_branch()) {
-      const auto &branch_meta = cur.branch();
+			assert(cur.numfilled() > 0);
+			const Position last_link = branch_meta.links_[cur.numfilled() - 1];
 
-      assert(cur.numfilled() > 0);
-      const Position last_link = branch_meta.links_[cur.numfilled() - 1];
+			cur = *Node::fetch_node(last_link);
+		}
 
-      if (auto ptr = Node::LinkToPtrMap().at(last_link); ptr) {
-        cur = *ptr;
-        continue;
-      }
-
-      // TODO:
-      // Fetch Node from media and put it in memory
-      // As of now this path should be avoided.
-      assert(false);
-    }
-
-    return Iterator{cur, cur.numfilled(), tree};
-  }
+		return Iterator{cur, cur.numfilled(), tree};
+	}
 
 public:
-  ~Iterator() noexcept = default;
+	~Iterator() noexcept = default;
 
-  Iterator &operator=(const Iterator &) = default;
+	Iterator &operator=(const Iterator &) = default;
 
-public: // Properties
-  optional_cref<Val> val() const noexcept {
-    assert(m_node->numfilled() > m_index);
-    assert(m_tree && m_node && m_index >= 0);
-    if (m_node->is_branch())
-      return std::nullopt;
-    const auto &leaf_meta = m_node->leaf();
-    return std::make_optional(std::cref(leaf_meta.vals_[m_index]));
-  }
+public:// Properties
+	optional_cref<Val> val() const noexcept {
+		assert(m_node->numfilled() > m_index);
+		assert(m_tree && m_node && m_index >= 0);
+		if (m_node->is_branch())
+			return std::nullopt;
+		const auto &leaf_meta = m_node->leaf();
+		return std::make_optional(std::cref(leaf_meta.vals_[m_index]));
+	}
 
-  optional_cref<Key> key() const noexcept {
-    assert(m_node->numfilled() > m_index);
-    assert(m_tree && m_node && m_index >= 0);
+	optional_cref<Key> key() const noexcept {
+		assert(m_node->numfilled() > m_index);
+		assert(m_tree && m_node && m_index >= 0);
 
-    return std::make_optional(std::cref(m_node->at(m_index)));
-  }
+		return std::make_optional(std::cref(m_node->at(m_index)));
+	}
 
-  const Node &node() const noexcept { return *m_node; }
+	const Node &node() const noexcept { return *m_node; }
 
-  Node &node_mut() noexcept { return *m_node; }
+	Node &node_mut() noexcept { return *m_node; }
 
-  long index() const noexcept { return m_index; }
+	long index() const noexcept { return m_index; }
 
 private:
-  static optional_cref<Node> parent_of_node(const Node &node) {
-    if (const auto mp = node.memparent(); mp.has_value())
-      return mp;
+	static optional_cref<Node> parent_of_node(const Node &node) {
+		if (const auto mp = node.memparent(); mp.has_value())
+			return mp;
 
-    const auto p_opt = node.parent();
-    assert(p_opt.has_value());
-    [[maybe_unused]] const Position p = p_opt.value();
-    // TODO: Fetch p or something
-    return std::nullopt;
-  }
+		const auto p_opt = node.parent();
+		assert(p_opt.has_value());
+		[[maybe_unused]] const Position p = p_opt.value();
+		// TODO: Fetch p or something
+		return std::nullopt;
+	}
 
-  /// @brief Get iterator to the value following the one that the current
-  /// iterator points to
-  ///
-  ///       | 3 6 |
-  ///      /   |   \
+	/// @brief Get iterator to the value following the one that the current
+	/// iterator points to
+	///
+	///       | 3 6 |
+	///      /   |   \
   ///  |1 2| |4 5| |7 8|
-  ///
-  /// For example, if the this points to 3 in the root node, the value
-  /// following it resides in the child node - 4.
-  /// @note As of now this is more like next_mem_()
-  std::optional<Iterator> next_() const noexcept {
-    // Case 1: Get follower in a child
-    const long numfilled = m_node->numfilled();
-    if (m_node->is_branch() && m_index < numfilled) {
-      const Position link_pos = m_node->branch().links_[m_index + 1];
-      Node &link_node = *Node::LinkToPtrMap().at(link_pos);
-      return std::make_optional(Iterator{link_node, 0, *m_tree});
-    }
+	///
+	/// For example, if the this points to 3 in the root node, the value
+	/// following it resides in the child node - 4.
+	/// @note As of now this is more like next_mem_()
+	std::optional<Iterator> next_() const noexcept {
+		// Case 1: Get follower in a child
+		const long numfilled = m_node->numfilled();
+		if (m_node->is_branch() && m_index < numfilled) {
+			const Position link_pos = m_node->branch().links_[m_index + 1];
+			Node &link_node = *Node::fetch_node(link_pos);
+			return std::make_optional(Iterator{link_node, 0, *m_tree});
+		}
 
-    // Case 2: Get follower in the current node
-    if (m_index < numfilled - 1 || m_node->is_rightmost())
-      return std::make_optional(Iterator{*m_node, m_index + 1, *m_tree});
+		// Case 2: Get follower in the current node
+		if (m_index < numfilled - 1 || m_node->is_rightmost())
+			return std::make_optional(Iterator{*m_node, m_index + 1, *m_tree});
 
-    assert(m_index == numfilled);
+		assert(m_index == numfilled);
 
-    auto first_more_than = [&](const Key &origin_ref) -> optional_cref<Node> {
-      auto parent_opt = parent_of_node(*m_node);
-      while (parent_opt.has_value()) {
-        const Node &parent = parent_opt.value().get();
-        if (origin_ref > parent.last()) {
-          parent_opt = parent_of_node(parent);
-          continue;
-        }
+		auto first_more_than = [&](const Key &origin_ref) -> optional_cref<Node> {
+			auto parent_opt = parent_of_node(*m_node);
+			while (parent_opt.has_value()) {
+				const Node &parent = parent_opt.value().get();
+				if (origin_ref > parent.last()) {
+					parent_opt = parent_of_node(parent);
+					continue;
+				}
 
-        return parent;
-      }
-      return std::nullopt;
-    };
+				return parent;
+			}
+			return std::nullopt;
+		};
 
-    // Case 3: Get follower in parent (or the parent's parent)
-    const auto origin_ref = m_node->at(m_index);
-    const auto parent_opt = first_more_than(origin_ref);
-    if (!parent_opt)
-      return std::nullopt;
+		// Case 3: Get follower in parent (or the parent's parent)
+		const auto origin_ref = m_node->at(m_index);
+		const auto parent_opt = first_more_than(origin_ref);
+		if (!parent_opt)
+			return std::nullopt;
 
-    const Node &parent = parent_opt.value();
+		const Node &parent = parent_opt.value();
 
-    for (long idx = 0; idx < parent.numfilled(); ++idx)
-      if (origin_ref < parent.at(idx))
-        return std::make_optional(
-            Iterator{const_cast<Node &>(parent), idx, *m_tree});
+		for (long idx = 0; idx < parent.numfilled(); ++idx)
+			if (origin_ref < parent.at(idx))
+				return std::make_optional(
+				        Iterator{const_cast<Node &>(parent), idx, *m_tree});
 
-    assert(false);
-    return std::nullopt;
-  }
+		assert(false);
+		return std::nullopt;
+	}
 
-  std::optional<Iterator> prev_() const noexcept {
-    // Case 1: Get predecessor in a child
-    if (m_node->is_branch() && m_index > 0) {
-      const Position link_pos = m_node->branch().links_[m_index - 1];
-      Node &link_node = *Node::LinkToPtrMap().at(link_pos);
-      return std::make_optional(
-          Iterator{link_node, link_node.numfilled(), *m_tree});
-    }
+	std::optional<Iterator> prev_() const noexcept {
+		// Case 1: Get predecessor in a child
+		if (m_node->is_branch() && m_index > 0) {
+			const Position link_pos = m_node->branch().links_[m_index - 1];
+			Node &link_node = *Node::fetch_node(link_pos);
+			return std::make_optional(
+			        Iterator{link_node, link_node.numfilled(), *m_tree});
+		}
 
-    // Case 2: Get predecessor in the current node
-    if (m_index > 0)
-      return std::make_optional(Iterator{*m_node, m_index - 1, *m_tree});
+		// Case 2: Get predecessor in the current node
+		if (m_index > 0)
+			return std::make_optional(Iterator{*m_node, m_index - 1, *m_tree});
 
-    assert(m_index == 0);
+		assert(m_index == 0);
 
-    // Case 3: Get predecessor in parent (or the parent's parent)
-    const auto origin_ref = m_node->at(m_index);
-    auto parent_opt = parent_of_node(*m_node);
-    while (parent_opt.has_value()) {
-      const Node &parent = parent_opt.value().get();
-      if (origin_ref < parent.first()) {
-        parent_opt = parent_of_node(parent);
-        continue;
-      }
+		// Case 3: Get predecessor in parent (or the parent's parent)
+		const auto origin_ref = m_node->at(m_index);
+		auto parent_opt = parent_of_node(*m_node);
+		while (parent_opt.has_value()) {
+			const Node &parent = parent_opt.value().get();
+			if (origin_ref < parent.first()) {
+				parent_opt = parent_of_node(parent);
+				continue;
+			}
 
-      for (long idx = 0; idx < parent.numfilled(); ++idx)
-        if (origin_ref > parent.at(idx))
-          return std::make_optional(
-              Iterator{const_cast<Node &>(parent), idx, *m_tree});
+			for (long idx = 0; idx < parent.numfilled(); ++idx)
+				if (origin_ref > parent.at(idx))
+					return std::make_optional(
+					        Iterator{const_cast<Node &>(parent), idx, *m_tree});
 
-      // Should be unreachable
-      assert(false);
-    }
+			// Should be unreachable
+			assert(false);
+		}
 
-    return std::nullopt;
-  }
+		return std::nullopt;
+	}
 
-public: // Iterator operations
-  reference operator*() const noexcept { return *m_node; }
+public:// Iterator operations
+	reference operator*() const noexcept { return *m_node; }
 
-  pointer operator->() const noexcept { return &(operator*()); }
+	pointer operator->() const noexcept { return &(operator*()); }
 
-  Iterator &operator++() {
-    assert(m_node->numfilled() > m_index);
-    assert(m_tree && m_node && m_index >= 0);
-    if (const auto next_opt = next_(); next_opt)
-      *this = next_opt.value();
-    return *this;
-  }
+	Iterator &operator++() {
+		assert(m_node->numfilled() > m_index);
+		assert(m_tree && m_node && m_index >= 0);
+		if (const auto next_opt = next_(); next_opt)
+			*this = next_opt.value();
+		return *this;
+	}
 
-  Iterator operator++(int) {
-    auto copy_ = *this;
-    this->operator++();
-    return copy_;
-  }
+	Iterator operator++(int) {
+		auto copy_ = *this;
+		this->operator++();
+		return copy_;
+	}
 
-  Iterator &operator--() {
-    assert(m_node->numfilled() <= m_index);
-    assert(m_tree && m_node && m_index >= 0);
-    if (const auto prev_opt = prev_(); prev_opt)
-      *this = prev_opt.value();
-    return *this;
-  }
+	Iterator &operator--() {
+		assert(m_node->numfilled() <= m_index);
+		assert(m_tree && m_node && m_index >= 0);
+		if (const auto prev_opt = prev_(); prev_opt)
+			*this = prev_opt.value();
+		return *this;
+	}
 
-  Iterator operator--(int) {
-    auto copy_ = *this;
-    this->operator--();
-    return copy_;
-  }
+	Iterator operator--(int) {
+		auto copy_ = *this;
+		this->operator--();
+		return copy_;
+	}
 
-  bool operator<=>(const Iterator &rhs) const noexcept = default;
+	bool operator<=>(const Iterator &rhs) const noexcept = default;
 
 private:
-  Node *m_node;
-  long m_index;
-  Btree<Config> *m_tree;
+	Node *m_node;
+	long m_index;
+	Btree<Config> *m_tree;
 };
 
 static_assert(std::bidirectional_iterator<Btree<DefaultBtreeConfig>::Iterator>);
 
-} // namespace internal::btree
+}// namespace internal::btree

--- a/src/internal/btree/Btree.h
+++ b/src/internal/btree/Btree.h
@@ -1,0 +1,85 @@
+#ifndef _EUGENE_BTREE_INCLUDED_
+#define _EUGENE_BTREE_INCLUDED_
+
+#include <memory>		// std::unique_ptr
+#include <optional>		// std::nullopt_t
+
+#include <internal/storage/Storage.h>
+
+template <typename T>
+consteval bool PowerOf2(T num) {
+	return (num & (num - 1)) == 0;
+}
+
+namespace internal::btree
+{
+
+	template <typename Config>
+	concept BtreeConfig = requires(Config conf) {
+		typename Config::Key;
+		typename Config::KeyRef;
+		typename Config::Val;
+		typename Config::StorageDev;
+
+		requires std::convertible_to<decltype(conf.ApplyCompression), bool>;
+		requires storage::StorageDevice<typename Config::StorageDev>;
+		requires std::unsigned_integral<decltype(conf.BtreeNodeSize)>;
+	} && PowerOf2(Config::BtreeNodeSize);
+
+	struct DefaultBtreeConfig {
+		using Key = uint32_t;
+		using KeyRef = Key;
+		using Val = uint32_t;
+		using StorageDev = storage::DefaultStorageDev;
+		static constexpr unsigned BtreeNodeSize = 1 << 10;
+		static constexpr bool ApplyCompression = false;
+	};
+
+	template <typename Config=DefaultBtreeConfig>
+		requires BtreeConfig<Config>
+	class Btree {
+	private:
+		using Position = storage::Position;
+		    
+		using Key = typename Config::Key;
+		using KeyRef = typename Config::KeyRef;
+		using Val = typename Config::Val;
+		using Storage = typename Config::StorageDev;
+		    
+		static constexpr bool ApplyCompression = Config::ApplyCompression;
+		static constexpr uint32_t BtreeNodeSize = Config::BtreeNodeSize;
+
+	public:
+		class Node;
+
+		class Iterator;
+
+	public:
+	    Btree() = default;
+
+            template<typename... Args>
+            explicit Btree(Args &&...args) noexcept
+	    	: m_storage(std::forward<Args>(args)...)
+	    {
+	    }
+
+	private:
+            Storage m_storage;
+            std::unique_ptr<Node> m_root;
+	};
+
+	template <BtreeConfig Config>
+	class Btree<Config>::Node {
+
+	};
+
+	template <BtreeConfig Config>
+	class Btree<Config>::Iterator {
+
+	};
+
+}
+
+
+
+#endif // _EUGENE_BTREE_INCLUDED_

--- a/src/internal/btree/Btree.h
+++ b/src/internal/btree/Btree.h
@@ -3,6 +3,11 @@
 
 #include <memory>		// std::unique_ptr
 #include <optional>		// std::nullopt_t
+#include <array>		// std::array
+#include <variant>		// std::variant
+#include <algorithm>		// std::min
+#include <utility>		// std::move, std::pair
+#include <cassert>		// assert
 
 #include <internal/storage/Storage.h>
 
@@ -10,6 +15,12 @@ template <typename T>
 consteval bool PowerOf2(T num) {
 	return (num & (num - 1)) == 0;
 }
+
+template <typename T>
+using optional_ref = std::optional<std::reference_wrapper<T>>;
+
+template <typename T>
+using optional_cref = std::optional<std::reference_wrapper<const T>>;
 
 namespace internal::btree
 {
@@ -37,7 +48,7 @@ namespace internal::btree
 
 	template <typename Config=DefaultBtreeConfig>
 		requires BtreeConfig<Config>
-	class Btree {
+	class Btree final {
 	private:
 		using Position = storage::Position;
 		    
@@ -65,21 +76,165 @@ namespace internal::btree
 
 	private:
             Storage m_storage;
-            std::unique_ptr<Node> m_root;
+            std::unique_ptr<Node> m_root {Node::RootPtr(*this, Node::Type::Leaf)};
 	};
 
 	template <BtreeConfig Config>
-	class Btree<Config>::Node {
+	class Btree<Config>::Node final {
+	private:
+		using Bt = Btree<Config>;
 
+	public:
+		enum class Type { Branch, Leaf };
+
+		struct Header {
+			storage::Position self_;
+			storage::Position prev_;
+			storage::Position next_;
+			storage::Position parent_;
+			Type type_;
+		};
+
+		struct MemHeader {
+			optional_cref<Node> prev_{};
+			optional_cref<Node> next_{};
+			optional_cref<Node> parent_{};
+			Type type_;
+			explicit MemHeader(Type t) : type_{t} {}
+		};
+
+	private:
+		static consteval unsigned long _calc_num_records(auto metasize) {
+			const auto leaf_size = metasize / (sizeof(Key) + sizeof(Val));
+			const auto branch_size = (metasize - sizeof(Position)) / (sizeof(Position) + sizeof(KeyRef));
+			return std::min(leaf_size, branch_size);
+		}
+
+		enum {
+			NodeLimit = Config::BtreeNodeSize,
+			MetaSize = NodeLimit - sizeof(Header),
+			NumRecords = _calc_num_records(MetaSize),
+			NumLinks = NumRecords + 1,
+		};
+
+		static_assert(NodeLimit > 0, "Node limit has to be a positive number.");
+		static_assert(PowerOf2(NodeLimit), "Node limit has to be a power of 2.");
+		static_assert(NumLinks == NumRecords + 1, "Node links must be one more than the number of records.");
+		static_assert(NumLinks > 2, "Node links must be more than 2.");
+
+	public:
+
+		using LeafKeyRecords = std::array<Key, NumRecords>;
+		using LeafValRecords = std::array<Val, NumRecords>;
+		using BranchRefs = std::array<KeyRef, NumRecords>;
+		using BranchLinks = std::array<Position, NumLinks>;
+
+		struct LeafMeta {
+			LeafKeyRecords keys_;
+			LeafValRecords vals_;
+		};
+
+		struct BranchMeta {
+			BranchRefs refs_;
+			BranchLinks links_;
+		};
+
+	public: // Getters
+
+		[[nodiscard]] bool is_branch() const noexcept {
+			if (m_header && m_header.value().type_ == Type::Branch) return true;
+			if (m_mem && m_mem.value().type_ == Type::Branch) return true;
+			return false;
+		}
+
+		[[nodiscard]] bool is_leaf() const noexcept {
+			return !is_branch();
+		}
+
+		[[nodiscard]] bool is_full() const noexcept {
+			return m_numfilled >= NumRecords;
+		}
+
+		[[nodiscard]] optional_cref<Header> header() const noexcept {
+			return std::make_optional(std::cref(m_header));
+		}
+
+		[[nodiscard]] optional_cref<MemHeader> memheader() const noexcept {
+			return std::make_optional(std::cref(m_mem));
+		}
+
+		[[nodiscard]] LeafMeta &leaf() {
+			return std::get<LeafMeta>(m_meta);
+		}
+
+		[[nodiscard]] BranchMeta &branch() {
+			return std::get<BranchMeta>(m_meta);
+		}
+
+		[[nodiscard]] auto range() const noexcept {
+			if (is_branch())
+				return std::make_pair(branch().keys_.begin(), branch().keys_end());
+			return std::make_pair(leaf().keys_.begin(), leaf().keys_end());
+		}
+
+		[[nodiscard]] const Key *raw() const noexcept {
+			if (is_branch())
+				return branch().keys_.data();
+			return leaf().keys_.data();
+		}
+
+		[[nodiscard]] const Key &at(unsigned long idx) const {
+			assert(m_numfilled > idx);
+			return raw()[idx];
+		}
+
+	public: // Constructors
+
+		Node(const Node &) = default;
+		Node (Node &&) noexcept = default;
+		Node &operator=(const Node &) = default;
+	    	Node& operator=(Node&& other) noexcept = default;
+
+		constexpr explicit Node(Bt &bt, std::optional<MemHeader> memheader = {}, std::optional<Header> header = {})
+			: m_header{std::move(header)},
+			  m_mem{std::move(memheader)},
+			  m_tree{bt}
+		{
+			if (is_branch())
+				m_meta = BranchMeta{};
+			else
+				m_meta = LeafMeta{};
+		}
+
+		static constexpr Node InMemoryNode(Bt &bt, MemHeader &&memheader)
+		{
+			return Node{bt, std::make_optional(memheader)};
+		}
+
+		static constexpr Node StoredNode(Bt &bt, Header &&header)
+		{
+			return Node{bt, std::nullopt, std::make_optional(header)};
+		}
+
+		static constexpr Node * const RootPtr(Bt &bt, Type type)
+		{
+			return new Node{ bt, MemHeader { type } };
+		}
+
+	private:
+		Bt &m_tree;
+		std::optional<Header> m_header{};
+		std::optional<MemHeader> m_mem{};
+
+		std::variant<LeafMeta, BranchMeta> m_meta;
+		unsigned long m_numfilled { 0 };
 	};
 
 	template <BtreeConfig Config>
-	class Btree<Config>::Iterator {
+	class Btree<Config>::Iterator final {
 
 	};
 
 }
-
-
 
 #endif // _EUGENE_BTREE_INCLUDED_

--- a/src/internal/btree/Btree.h
+++ b/src/internal/btree/Btree.h
@@ -1,21 +1,23 @@
 #ifndef _EUGENE_BTREE_INCLUDED_
 #define _EUGENE_BTREE_INCLUDED_
 
-#include <memory>		// std::unique_ptr
-#include <optional>		// std::nullopt_t
-#include <array>		// std::array
-#include <variant>		// std::variant
-#include <algorithm>		// std::min
-#include <utility>		// std::move, std::pair
-#include <cassert>		// assert
-#include <tuple>		// std::tie
-
 #include <internal/storage/Storage.h>
 
-template <typename T>
-consteval bool PowerOf2(T num) {
-	return (num & (num - 1)) == 0;
+#include <algorithm>     // std::min
+#include <array>         // std::array
+#include <cassert>       // assert
+#include <memory>        // std::unique_ptr
+#include <optional>      // std::nullopt_t
+#include <tuple>         // std::tie
+#include <unordered_map> // std::unordered_map
+#include <utility>       // std::move, std::pair
+#include <variant>       // std::variant
+
+template <typename T> consteval bool PowerOf2(T num) {
+  return (num & (num - 1)) == 0;
 }
+
+#define unsafe__ /* unsafe function */
 
 template <typename T>
 using optional_ref = std::optional<std::reference_wrapper<T>>;
@@ -23,574 +25,624 @@ using optional_ref = std::optional<std::reference_wrapper<T>>;
 template <typename T>
 using optional_cref = std::optional<std::reference_wrapper<const T>>;
 
-template <typename T>
-optional_ref<T> uncref(optional_cref<T> copt) noexcept {
-	return std::nullopt;
+namespace internal::btree {
+
+template <typename Config>
+concept BtreeConfig = requires(Config conf) {
+  typename Config::Key;
+  typename Config::KeyRef;
+  typename Config::Val;
+  typename Config::StorageDev;
+
+  requires std::convertible_to<decltype(conf.ApplyCompression), bool>;
+  requires storage::StorageDevice<typename Config::StorageDev>;
+  requires std::unsigned_integral<decltype(conf.BtreeNodeSize)>;
 }
-
-namespace internal::btree
-{
-
-	template <typename Config>
-	concept BtreeConfig = requires(Config conf) {
-		typename Config::Key;
-		typename Config::KeyRef;
-		typename Config::Val;
-		typename Config::StorageDev;
-
-		requires std::convertible_to<decltype(conf.ApplyCompression), bool>;
-		requires storage::StorageDevice<typename Config::StorageDev>;
-		requires std::unsigned_integral<decltype(conf.BtreeNodeSize)>;
-	} && PowerOf2(Config::BtreeNodeSize);
-
-	struct DefaultBtreeConfig {
-		using Key = uint32_t;
-		using KeyRef = Key;
-		using Val = uint32_t;
-		using StorageDev = storage::DefaultStorageDev;
-		static constexpr unsigned BtreeNodeSize = 1 << 10;
-		static constexpr bool ApplyCompression = false;
-	};
-
-	template <typename Config=DefaultBtreeConfig>
-		requires BtreeConfig<Config>
-	class Btree final {
-	private:
-		using Position = storage::Position;
-		    
-		using Key = typename Config::Key;
-		using KeyRef = typename Config::KeyRef;
-		using Val = typename Config::Val;
-		using Storage = typename Config::StorageDev;
-		    
-		static constexpr bool ApplyCompression = Config::ApplyCompression;
-		static constexpr uint32_t BtreeNodeSize = Config::BtreeNodeSize;
-
-	public:
-		class Node;
-
-		class Iterator;
-
-	public: // Constructors
-	    Btree() = default;
-
-            template<typename... Args>
-            explicit Btree(Args &&...args) noexcept
-	    	: m_storage(std::forward<Args>(args)...)
-	    {
-	    }
-
-	public: // API
-
-	    Iterator begin() const noexcept {}
-	    Iterator end() const noexcept {}
-
-	    Iterator insert(const Key& key, const Val& val) noexcept
-	    {
-		Node &cur = m_root;
-		while (true) {
-			auto [it, found] = cur.find(key);
-			if (found) {
-				assert(it.key() && it.key().value() == key);
-				return it;
-			}
-			if (cur.is_leaf())
-				return cur.insert(key, val, it);
-			if (it == cur.end())
-				break;
-			cur = *it;
-		}
-
-		return end();
-	    }
-
-	    std::optional<Iterator> find(const Key &target) noexcept
-	    {
-		Node &cur = const_cast<Node &>(m_root);
-		while (true) {
-			Iterator it;
-			bool next;
-			std::tie(it, next) = cur.find(target);
-			if (cur.is_leaf()) {
-				if (!next)
-					break;
-				return std::make_optional(it);
-			}
-
-			if (next)
-				++it;
-
-			cur = *it;
-		}
-
-		return std::nullopt;
-	    }
-
-	    optional_cref<Val> get(const Key &target) const noexcept
-	    {
-		auto maybe_it = find(target);
-		if (!maybe_it)
-			return std::nullopt;
-
-		auto it = maybe_it.value();
-		if (it == end())
-			return std::nullopt;
-
-		auto maybe_val = it.val();
-		return maybe_val;
-	    }
-
-	    optional_cref<Val> operator[](const Key &target) const noexcept
-	    {
-		    return get(target);
-	    }
-
-	    void erase(const Key &target) noexcept
-	    {
-		    assert(("Function is not yet implemented -- Btree::erase", false));
-	    }
-
-
-	public: // Getters
-
-	    const Node& root() const noexcept {
-		    return m_root;
-	    }
-
-	    Node& root() noexcept {
-		    return m_root;
-	    }
-
-	private:
-            Storage m_storage;
-            Node m_root = Node::Root(*this, Node::Type::Leaf);
-	};
-
-	template <BtreeConfig Config>
-	class Btree<Config>::Node final {
-	private:
-		using Bt = Btree<Config>;
-
-	public:
-		enum class Type { Branch, Leaf };
-
-		struct Header {
-			storage::Position self_{storage::PositionPoison};
-			storage::Position prev_{storage::PositionPoison};
-			storage::Position next_{storage::PositionPoison};
-			storage::Position parent_{storage::PositionPoison};
-			Type type_;
-
-			explicit Header(Type t) : type_{t} {}
-			explicit Header(std::nullopt_t) {}
-			Header(const Header &) = default;
-		};
-
-		struct MemHeader {
-			optional_cref<Node> prev_{};
-			optional_cref<Node> next_{};
-			optional_cref<Node> parent_{};
-			Type type_;
-
-			explicit MemHeader(Type t) : type_{t} {}
-			explicit MemHeader(std::nullopt_t) {}
-			MemHeader(const MemHeader &) = default;
-		};
-
-	private:
-		static consteval unsigned long _calc_num_records(auto metasize) {
-			const auto leaf_size = metasize / (sizeof(Key) + sizeof(Val));
-			const auto branch_size = (metasize - sizeof(Position)) / (sizeof(Position) + sizeof(KeyRef));
-			return std::min(leaf_size, branch_size);
-		}
-
-		enum {
-			NodeLimit = Config::BtreeNodeSize,
-			MetaSize = NodeLimit - sizeof(Header),
-			NumRecords = _calc_num_records(MetaSize),
-			NumLinks = NumRecords + 1,
-		};
-
-		static_assert(NodeLimit > 0, "Node limit has to be a positive number.");
-		static_assert(PowerOf2(NodeLimit), "Node limit has to be a power of 2.");
-		static_assert(NumLinks == NumRecords + 1, "Node links must be one more than the number of records.");
-		static_assert(NumLinks > 2, "Node links must be more than 2.");
-
-	public:
-
-		using LeafKeyRecords = std::array<Key, NumRecords>;
-		using LeafValRecords = std::array<Val, NumRecords>;
-		using BranchRefs = std::array<KeyRef, NumRecords>;
-		using BranchLinks = std::array<Position, NumLinks>;
-
-		struct LeafMeta {
-			LeafKeyRecords keys_;
-			LeafValRecords vals_;
-		};
-
-		struct BranchMeta {
-			BranchRefs refs_;
-			BranchLinks links_;
-		};
-
-	public: // Getters
-
-		[[nodiscard]] bool is_branch() const noexcept {
-			if (m_header && m_header.value().type_ == Type::Branch) return true;
-			if (m_mem && m_mem.value().type_ == Type::Branch) return true;
-			return false;
-		}
-
-		[[nodiscard]] bool is_leaf() const noexcept {
-			return !is_branch();
-		}
-
-		[[nodiscard]] bool is_full() const noexcept {
-			assert(m_numfilled <= NumRecords);
-			return m_numfilled == NumRecords;
-		}
-
-		[[nodiscard]] bool is_ok() const noexcept {
-			return m_numfilled < NumRecords;
-		}
-
-		[[nodiscard]] optional_cref<Header> header() const noexcept {
-			return std::make_optional(std::cref(m_header));
-		}
-
-		[[nodiscard]] optional_cref<MemHeader> memheader() const noexcept {
-			return std::make_optional(std::cref(m_mem));
-		}
-
-		[[nodiscard]] LeafMeta &leaf() {
-			return std::get<LeafMeta>(m_meta);
-		}
-
-		[[nodiscard]] BranchMeta &branch() {
-			return std::get<BranchMeta>(m_meta);
-		}
-
-		[[nodiscard]] const LeafMeta &leaf() const {
-			return std::get<LeafMeta>(m_meta);
-		}
-
-		[[nodiscard]] const BranchMeta &branch() const {
-			return std::get<BranchMeta>(m_meta);
-		}
-
-		[[nodiscard]] auto range() const noexcept {
-			if (is_branch())
-				return std::make_pair(branch().refs_.begin(), branch().refs_.end());
-			return std::make_pair(leaf().keys_.begin(), leaf().keys_.end());
-		}
-
-		[[nodiscard]] const Key *raw() const noexcept {
-			if (is_branch())
-				return branch().refs_.data();
-			return leaf().keys_.data();
-		}
-
-		[[nodiscard]] const Key &at(unsigned long idx) const {
-			assert(m_numfilled > idx);
-			return raw()[idx];
-		}
-
-		[[nodiscard]] Iterator begin() noexcept {
-			return Iterator { *this, 0, m_tree };
-		}
-
-		[[nodiscard]] Iterator end() noexcept {
-			return Iterator { *this, m_numfilled, m_tree };
-		}
-
-		[[nodiscard]] std::optional<storage::Position> self() const noexcept {
-			if (m_header)
-				return m_header.value().self_;
-			return std::nullopt;
-		}
-
-		[[nodiscard]] std::optional<storage::Position> parent() const noexcept {
-			if (m_header)
-				return m_header.value().parent_;
-			return std::nullopt;
-		}
-
-		[[nodiscard]] optional_cref<Node> memparent() const noexcept {
-			if (m_mem)
-				return m_mem.value().parent_;
-			return std::nullopt;
-		}
-
-		void set_numfilled(unsigned long numfilled) noexcept {
-			m_numfilled = numfilled;
-		}
-
-		void set_prev(Node * const mprev, std::optional<storage::Position> prev = {}) noexcept {
-			if (m_mem)
-				m_mem.value().prev_.emplace(std::cref(*mprev));
-				// m_mem.value().prev_ = std::make_optional<std::cref(*mprev)>;
-
-			if (m_header && prev)
-				m_header.value().prev_ = prev.value(); 
-		}
-
-		void set_next(Node * const mnext, std::optional<storage::Position> next = {}) noexcept {
-			if (m_mem)
-				m_mem.value().next_.emplace(std::cref(*mnext));
-
-			if (m_header && next)
-				m_header.value().next_ = next.value(); 
-		}
-
-	public: // Constructors
-
-
-		constexpr explicit Node(Bt &bt, std::optional<MemHeader> memheader = {}, std::optional<Header> header = {})
-			: m_header{std::move(header)},
-			  m_mem{std::move(memheader)},
-			  m_tree{bt}
-		{
-			if (is_branch())
-				m_meta = BranchMeta{};
-			else
-				m_meta = LeafMeta{};
-		}
-
-		static constexpr Node InMemoryNode(Bt &bt, MemHeader &&memheader)
-		{
-			return Node{bt, std::make_optional(memheader)};
-		}
-
-		static constexpr Node StoredNode(Bt &bt, Header &&header)
-		{
-			return Node{bt, std::nullopt, std::make_optional(header)};
-		}
-
-		static constexpr Node Root(Bt &bt, Type type)
-		{
-			return Node{ bt, MemHeader { type } };
-		}
-
-		Node(const Node &) = default;
-
-		Node &operator=(const Node &rhs) noexcept
-		{
-			m_tree = rhs.m_tree;
-			m_numfilled = rhs.m_numfilled;
-			m_mem = rhs.m_mem;
-			m_header = rhs.m_header;
-			m_meta = rhs.m_meta;
-			return *this;
-		}
-
-	private: // Helpers
-
-		Iterator make_sibling(LeafMeta &asleaf, unsigned long middle_idx) noexcept
-		{
-			const auto pivot_idx = middle_idx + 1;
-			auto sibling_ptr = std::make_shared<Node>(
-				m_tree, m_mem, m_header
-			);
-			Node &sibling = *sibling_ptr;
-			auto &sleaf = sibling.leaf();
-
-			std::copy(asleaf.keys_.begin() + pivot_idx, asleaf.keys_.end(), sleaf.keys_.begin());
-			std::copy(asleaf.vals_.begin() + pivot_idx, asleaf.vals_.end(), sleaf.vals_.begin());
-
-			sibling.set_prev(this, self());
-			set_next(sibling_ptr.get(), sibling.self());
-
-			sibling.set_numfilled(NumRecords - pivot_idx);
-			set_numfilled(middle_idx);
-		}
-
-		Iterator raise_to_parent(Iterator it) noexcept
-		{
-			assert(it.node());
-			Node &node = it.node().value();
-
-			return it;
-		}
-		
-	public: // API
-
-		Iterator insert(const Key &key, const Val &val, Iterator it)
-		{
-			assert(it.key() && it.key().value() != key);
-
-			const auto maybe_idx = it.index();
-			if (!maybe_idx)
-				return Iterator::end(m_tree);
-			const auto idx = maybe_idx.value();
-
-			auto &as_leaf = leaf();
-			as_leaf.keys_[idx] = key;
-			as_leaf.vals_[idx] = val;
-			++m_numfilled;
-
-			if (is_ok())
-				return it;
-
-			// Rebalance
-
-			const auto middle_idx = (NumRecords + 1) / 2;
-			Iterator pivot = make_sibling(leaf(), middle_idx);
-			Iterator pos = raise_to_parent(pivot);
-			return pos;
-		}
-
-		std::pair<Iterator, bool> find(const Key &target) noexcept
-		{
-			auto [lo, _] = range();
-			auto hi = lo + m_numfilled;
-			const auto beginning = lo;
-
-			while (lo < hi) {
-				auto mid = lo;
-				std::advance(mid, std::distance(lo, hi) / 2);
-				if (target > *mid)
-					lo = mid + 1;
-				else
-					hi = mid;
-			}
-
-			unsigned long idx = std::distance(beginning, hi);
-			auto it = Iterator{*this, idx, m_tree};
-			return std::make_pair(it, *hi == target);
-		}
-
-	private:
-		std::optional<Header> m_header{ std::nullopt };
-		std::optional<MemHeader> m_mem{ std::nullopt };
-		Bt &m_tree;
-
-		std::variant<LeafMeta, BranchMeta> m_meta;
-		unsigned long m_numfilled { 0 };
-	};
-
-	template <BtreeConfig Config>
-	class Btree<Config>::Iterator final {
-	public: // Iterator traits
-		using difference_type = unsigned long;
-		using value_type = Node;
-		using pointer = Node *;
-		using reference = Node &;
-		using iterator_category = std::bidirectional_iterator_tag;
-
-	private:
-		using Val = Config::Val;
-		using Key = Config::Key;
-
-
-	public: // Constructor
-
-		Iterator() = default;
-
-		Iterator(Node& node, unsigned long index, Btree &tree)
-			: m_node{ std::make_optional(std::ref(node)) },
-			  m_index{ std::make_optional(index) },
-			  m_tree{ std::make_optional(std::ref(tree)) }
-		{
-		}
-
-		explicit Iterator(Btree &tree)
-			: m_tree{ std::make_optional(std::ref(tree)) }
-		{
-		}
-
-		static Iterator end(Btree &tree) noexcept {
-			return Iterator{ tree };
-		}
-
-		Iterator& operator=(const Iterator&) = default;
-
-	public: // Properties
-
-		optional_cref<Val> val() const noexcept
-		{
-			if (!m_node)
-				return std::nullopt;
-
-			Node &noderef = m_node.value();
-			return std::nullopt;
-		}
-
-		optional_cref<Key> key() const noexcept
-		{
-			if (!m_node || !m_index)
-				return std::nullopt;
-
-			Node &noderef = m_node.value();
-			const auto index_ = m_index.value();
-			auto [begin, end] = noderef.range();
-			if (std::distance(begin, end) <= index_)
-				return std::nullopt;
-			std::advance(begin, index_);
-			return *begin;
-		}
-
-		optional_ref<Node> node() const noexcept
-		{
-			return m_node;
-		}
-
-		std::optional<unsigned long> index() const noexcept
-		{
-			return m_index;
-		}
-
-	public: // Iterator operations
-
-		reference operator*() const
-		{
-			assert(m_node.has_value());
-			return m_node.value();
-		}
-
-		pointer operator->() const
-		{
-			return &(operator*());
-		}
-
-		Iterator& operator++()
-		{
-
-		}
-
-		Iterator operator++(int)
-		{
-
-		}
-
-		Iterator& operator--()
-		{
-
-		}
-
-		Iterator operator--(int)
-		{
-
-		}
-
-		Iterator operator+(unsigned long)
-		{
-
-		}
-
-		// bool operator<=>(const Iterator &) const noexcept = default;
-		//
-		bool operator==(const Iterator &rhs) const noexcept
-		{
-
-		}
-
-	private:
-		optional_ref<Node> m_node{};
-		std::optional<size_t> m_index{};
-		optional_ref<Btree<Config>> m_tree{};
-	};
-
-}
-
+&&PowerOf2(Config::BtreeNodeSize);
+
+struct DefaultBtreeConfig {
+  using Key = uint32_t;
+  using KeyRef = Key;
+  using Val = uint32_t;
+  using StorageDev = storage::DefaultStorageDev;
+  static constexpr unsigned BtreeNodeSize = 1 << 10;
+  static constexpr bool ApplyCompression = false;
+};
+
+template <typename Config = DefaultBtreeConfig>
+requires BtreeConfig<Config>
+class Btree final {
+private:
+  using Position = storage::Position;
+
+  using Key = typename Config::Key;
+  using KeyRef = typename Config::KeyRef;
+  using Val = typename Config::Val;
+  using Storage = typename Config::StorageDev;
+
+  static constexpr bool ApplyCompression = Config::ApplyCompression;
+  static constexpr uint32_t BtreeNodeSize = Config::BtreeNodeSize;
+
+public:
+  class Node;
+  friend Node;
+
+  class Iterator;
+  friend Iterator;
+
+public: // Constructors
+  Btree() = default;
+
+  template <typename... Args>
+  explicit Btree(Args &&...args) noexcept
+      : m_storage(std::forward<Args>(args)...) {}
+
+public:
+  ~Btree() noexcept = default;
+
+  bool operator<=>(const Btree &rhs) const noexcept {
+    return m_root.operator<=>(rhs);
+  }
+
+public: // API
+  Iterator begin() noexcept { return Iterator::begin(*this); }
+
+  Iterator end() noexcept { return Iterator::end(*this); }
+
+  Iterator insert(const Key &key, const Val &val) noexcept {
+    Node &cur = m_root;
+    while (true) {
+      auto [it, found] = cur.find(key);
+      if (found) {
+        assert(it.key() && it.key().value() == key);
+        return it;
+      }
+      if (cur.is_leaf())
+        return cur.insert(key, val, it);
+      if (it == cur.end())
+        break;
+      cur = *it;
+    }
+
+    return end();
+  }
+
+  std::optional<Iterator> find(const Key &target) noexcept {
+    Node &cur = const_cast<Node &>(m_root);
+    while (true) {
+      auto [it, next] = cur.find(target);
+      if (cur.is_leaf()) {
+        if (!next)
+          break;
+        return std::make_optional(it);
+      }
+
+      if (next)
+        ++it;
+
+      cur = *it;
+    }
+
+    return std::nullopt;
+  }
+
+  optional_cref<Val> get(const Key &target) const noexcept {
+    auto maybe_it = find(target);
+    if (!maybe_it)
+      return std::nullopt;
+
+    auto it = maybe_it.value();
+    if (it == end())
+      return std::nullopt;
+
+    auto maybe_val = it.val();
+    return maybe_val;
+  }
+
+  optional_cref<Val> operator[](const Key &target) const noexcept {
+    return get(target);
+  }
+
+  void erase(const Key &target) noexcept {
+    assert(("Function is not yet implemented -- Btree::erase", false));
+  }
+
+public: // Getters
+  const Node &root() const noexcept { return m_root; }
+
+  Node &root() noexcept { return m_root; }
+
+private:
+  Storage m_storage;
+  Node m_root = Node::Root(*this, Node::Type::Leaf);
+};
+
+template <BtreeConfig Config> class Btree<Config>::Node final {
+private:
+  using Bt = Btree<Config>;
+  friend Bt::Iterator;
+
+public:
+  enum class Type { Branch, Leaf };
+
+  struct Header {
+    storage::Position self_{storage::PositionPoison};
+    storage::Position prev_{storage::PositionPoison};
+    storage::Position next_{storage::PositionPoison};
+    storage::Position parent_{storage::PositionPoison};
+    Type type_;
+
+    explicit Header(Type t) : type_{t} {}
+    explicit Header(std::nullopt_t) {}
+    Header(const Header &) = default;
+    bool operator<=>(const Header &) const noexcept = default;
+  };
+
+  struct MemHeader {
+    optional_ref<Node> prev_{};
+    optional_ref<Node> next_{};
+    optional_ref<Node> parent_{};
+    Type type_;
+
+    explicit MemHeader(Type t) : type_{t} {}
+    explicit MemHeader(std::nullopt_t) {}
+    MemHeader(const MemHeader &) = default;
+
+    bool operator<=>(const MemHeader &) const noexcept = default;
+  };
+
+private:
+  static consteval long _calc_num_records(auto metasize) {
+    const auto leaf_size = metasize / (sizeof(Key) + sizeof(Val));
+    const auto branch_size =
+        (metasize - sizeof(Position)) / (sizeof(Position) + sizeof(KeyRef));
+    return std::min(leaf_size, branch_size);
+  }
+
+  enum {
+    NodeLimit = Config::BtreeNodeSize,
+    MetaSize = NodeLimit - sizeof(Header),
+    NumRecords = _calc_num_records(MetaSize),
+    NumLinks = NumRecords + 1,
+  };
+
+  static_assert(NodeLimit > 0, "Node limit has to be a positive number.");
+  static_assert(PowerOf2(NodeLimit), "Node limit has to be a power of 2.");
+  static_assert(NumLinks == NumRecords + 1,
+                "Node links must be one more than the number of records.");
+  static_assert(NumLinks > 2, "Node links must be more than 2.");
+
+public:
+  using LeafKeyRecords = std::array<Key, NumRecords>;
+  using LeafValRecords = std::array<Val, NumRecords>;
+  using BranchRefs = std::array<KeyRef, NumRecords>;
+  using BranchLinks = std::array<Position, NumLinks>;
+
+  struct LeafMeta {
+    LeafKeyRecords keys_;
+    LeafValRecords vals_;
+
+    bool operator<=>(const LeafMeta &) const noexcept = default;
+  };
+
+  struct BranchMeta {
+    BranchRefs refs_;
+    BranchLinks links_;
+
+    bool operator<=>(const BranchMeta &) const noexcept = default;
+  };
+
+private:
+  // Maps BranchMeta::links_ of type Position to actual in-memory Node *
+  static auto &LinkMap() noexcept {
+    static std::unordered_map<Position, Node *> mapper_{};
+    return mapper_;
+  }
+
+public: // Getters
+  [[nodiscard]] bool is_branch() const noexcept {
+    if (m_header && m_header.value().type_ == Type::Branch)
+      return true;
+    if (m_mem && m_mem.value().type_ == Type::Branch)
+      return true;
+    return false;
+  }
+
+  [[nodiscard]] bool is_leaf() const noexcept { return !is_branch(); }
+
+  [[nodiscard]] bool is_full() const noexcept {
+    assert(m_numfilled <= NumRecords);
+    return m_numfilled == NumRecords;
+  }
+
+  [[nodiscard]] bool is_ok() const noexcept { return m_numfilled < NumRecords; }
+
+  [[nodiscard]] bool is_empty() const noexcept { return !m_numfilled; }
+
+  [[nodiscard]] optional_cref<Header> header() const noexcept {
+    if (!m_header.has_value())
+      return std::nullopt;
+    return std::make_optional(std::cref(m_header.value()));
+  }
+
+  [[nodiscard]] optional_cref<MemHeader> memheader() const noexcept {
+    if (!m_mem.has_value())
+      return std::nullopt;
+    return std::make_optional(std::cref(m_mem.value()));
+  }
+
+  [[nodiscard]] LeafMeta &leaf() { return std::get<LeafMeta>(m_meta); }
+
+  [[nodiscard]] BranchMeta &branch() { return std::get<BranchMeta>(m_meta); }
+
+  [[nodiscard]] const LeafMeta &leaf() unsafe__ const {
+    return std::get<LeafMeta>(m_meta);
+  }
+
+  [[nodiscard]] const BranchMeta &branch() unsafe__ const {
+    return std::get<BranchMeta>(m_meta);
+  }
+
+  [[nodiscard]] auto range() const noexcept {
+    if (is_branch())
+      return std::make_pair(branch().refs_.begin(), branch().refs_.end());
+    return std::make_pair(leaf().keys_.begin(), leaf().keys_.end());
+  }
+
+  [[nodiscard]] const Key *raw() const noexcept {
+    if (is_branch())
+      return branch().refs_.data();
+    return leaf().keys_.data();
+  }
+
+  [[nodiscard]] const Key &at(long idx) const noexcept {
+    assert(m_numfilled > idx);
+    return raw()[idx];
+  }
+
+  [[nodiscard]] const Key &first() const noexcept { return at(0); }
+
+  [[nodiscard]] const Key &last() const noexcept { return at(m_numfilled - 1); }
+
+  [[nodiscard]] Iterator begin() noexcept {
+    return Iterator{*this, 0, *m_tree};
+  }
+
+  [[nodiscard]] Iterator end() noexcept {
+    return Iterator{*this, m_numfilled, *m_tree};
+  }
+
+  [[nodiscard]] std::optional<storage::Position> self() const noexcept {
+    if (m_header)
+      return m_header.value().self_;
+    return std::nullopt;
+  }
+
+  [[nodiscard]] std::optional<storage::Position> parent() const noexcept {
+    if (m_header)
+      return m_header.value().parent_;
+    return std::nullopt;
+  }
+
+  [[nodiscard]] optional_cref<Node> memparent() const noexcept {
+    if (m_mem)
+      return m_mem.value().parent_;
+    return std::nullopt;
+  }
+
+  void set_numfilled(long numfilled) noexcept { m_numfilled = numfilled; }
+
+  [[nodiscard]] long numfilled() const noexcept { return m_numfilled; }
+
+  void set_prev(Node *const mprev,
+                std::optional<storage::Position> prev = {}) noexcept {
+    if (m_mem)
+      m_mem.value().prev_.emplace(std::ref(*mprev));
+
+    if (m_header && prev)
+      m_header.value().prev_ = prev.value();
+  }
+
+  void set_next(Node *const mnext,
+                std::optional<storage::Position> next = {}) noexcept {
+    if (m_mem)
+      m_mem.value().next_.emplace(std::ref(*mnext));
+
+    if (m_header && next)
+      m_header.value().next_ = next.value();
+  }
+
+public: // Constructors
+  constexpr explicit Node(Bt &bt, std::optional<MemHeader> memheader = {},
+                          std::optional<Header> header = {})
+      : m_header{std::move(header)}, m_mem{std::move(memheader)}, m_tree{&bt} {
+    if (is_branch())
+      m_meta = BranchMeta{};
+    else
+      m_meta = LeafMeta{};
+  }
+
+  Node(const Node &) = default;
+
+  static constexpr Node InMemoryNode(Bt &bt, MemHeader &&memheader) {
+    return Node{bt, std::make_optional(memheader)};
+  }
+
+  static constexpr Node StoredNode(Bt &bt, Header &&header) {
+    return Node{bt, std::nullopt, std::make_optional(header)};
+  }
+
+  static constexpr Node Root(Bt &bt, Type type) {
+    return Node{bt, MemHeader{type}};
+  }
+
+public:
+  ~Node() noexcept = default;
+
+  Node &operator=(const Node &rhs) noexcept = default;
+
+  bool operator<=>(const Node &rhs) const noexcept = default;
+
+private: // Helpers
+  Iterator make_sibling(LeafMeta &asleaf, long middle_idx) noexcept {
+    const auto pivot_idx = middle_idx + 1;
+    auto sibling_ptr = std::make_shared<Node>(*m_tree, m_mem, m_header);
+    Node &sibling = *sibling_ptr;
+    auto &sleaf = sibling.leaf();
+
+    std::copy(asleaf.keys_.begin() + pivot_idx, asleaf.keys_.end(),
+              sleaf.keys_.begin());
+    std::copy(asleaf.vals_.begin() + pivot_idx, asleaf.vals_.end(),
+              sleaf.vals_.begin());
+
+    sibling.set_prev(this, self());
+    set_next(sibling_ptr.get(), sibling.self());
+
+    sibling.set_numfilled(NumRecords - pivot_idx);
+    set_numfilled(middle_idx);
+    return Iterator{*this, middle_idx, *m_tree};
+  }
+
+  Iterator raise_to_parent(Iterator it) noexcept {
+    [[maybe_unused]] Node &node = it.node_mut();
+
+    return it;
+  }
+
+public: // API
+  Iterator insert(const Key &key, const Val &val, Iterator it) {
+    assert(it.key() && it.key().value() != key);
+
+    const auto idx = it.index();
+    auto &as_leaf = leaf();
+    as_leaf.keys_[idx] = key;
+    as_leaf.vals_[idx] = val;
+    ++m_numfilled;
+
+    if (is_ok())
+      return it;
+
+    // Rebalance
+
+    const auto middle_idx = (NumRecords + 1) / 2;
+    Iterator pivot = make_sibling(leaf(), middle_idx);
+    Iterator pos = raise_to_parent(pivot);
+    return pos;
+  }
+
+  std::pair<Iterator, bool> find(const Key &target) noexcept {
+    auto [lo, _] = range();
+    auto hi = lo + m_numfilled;
+    const auto beginning = lo;
+
+    while (lo < hi) {
+      auto mid = lo;
+      std::advance(mid, std::distance(lo, hi) / 2);
+      if (target > *mid)
+        lo = mid + 1;
+      else
+        hi = mid;
+    }
+
+    long idx = std::distance(beginning, hi);
+    auto it = Iterator{*this, idx, *m_tree};
+    return std::make_pair(it, *hi == target);
+  }
+
+private:
+  std::optional<Header> m_header{std::nullopt};
+  std::optional<MemHeader> m_mem{std::nullopt};
+  Bt *m_tree;
+
+  std::variant<LeafMeta, BranchMeta> m_meta;
+  long m_numfilled{0};
+};
+
+template <BtreeConfig Config> class Btree<Config>::Iterator final {
+public: // Iterator traits
+  using difference_type = long;
+  using value_type = Node;
+  using pointer = Node *;
+  using reference = Node &;
+  using iterator_category = std::bidirectional_iterator_tag;
+
+private:
+  using Val = Config::Val;
+  using Key = Config::Key;
+
+public: // Constructor
+  Iterator() = default;
+
+  Iterator(const Iterator &) noexcept = default;
+
+  /// Tree::begin iterator
+  explicit Iterator(Btree &tree, bool is_ok = true)
+      : m_node{&tree.m_root}, m_index{0}, m_tree{&tree},
+        m_ok{!(is_ok && tree.m_root.is_empty())} {}
+
+  /// Iterator to a specific location in the tree
+  Iterator(Node &node, long index, Btree &tree)
+      : m_node{&node}, m_index{index}, m_tree{&tree} {}
+
+  static Iterator begin(Btree &tree) noexcept { return Iterator{tree}; }
+
+  static Iterator end(Btree &tree) noexcept { return Iterator{tree, true}; }
+
+public:
+  ~Iterator() noexcept = default;
+
+  Iterator &operator=(const Iterator &) = default;
+
+public: // Properties
+  optional_cref<Val> val() const noexcept { return std::nullopt; }
+
+  optional_cref<Key> key() const noexcept { return std::nullopt; }
+
+  const Node &node() const noexcept { return *m_node; }
+
+  Node &node_mut() noexcept { return *m_node; }
+
+  long index() const noexcept { return m_index; }
+
+private:
+  static optional_cref<Node> parent_of_node(const Node &node) {
+    if (const auto mp = node.memparent(); mp.has_value())
+      return mp;
+
+    const auto p_opt = node.parent();
+    assert(p_opt.has_value());
+    [[maybe_unused]] const Position p = p_opt.value();
+    // TODO: Fetch p or something
+    return std::nullopt;
+  }
+
+  /// @brief Get iterator to the value following the one that the current
+  /// iterator points to
+  ///
+  ///       | 3 6 |
+  ///      /   |   \
+  ///  |1 2| |4 5| |7 8|
+  ///
+  /// For example, if the this points to 3 in the root node, the value following
+  /// it resides in the child node - 4.
+  /// @note As of now this is more like next_mem_()
+  std::optional<Iterator> next_() const noexcept {
+    // Case 1: Get follower in a child
+    const long numfilled = m_node->numfilled();
+    if (m_node->is_branch() && m_index < numfilled) {
+      const Position link_pos = m_node->branch().links_[m_index + 1];
+      Node &link_node = *Node::LinkMap().at(link_pos);
+      return std::make_optional(Iterator{link_node, 0, *m_tree});
+    }
+
+    // Case 2: Get follower in the current node
+    if (m_index < numfilled - 1)
+      return std::make_optional(Iterator{*m_node, m_index + 1, *m_tree});
+
+    assert(m_index == numfilled);
+
+    // Case 3: Get follower in parent (or the parent's parent)
+    const auto origin_ref = m_node->at(m_index);
+    auto parent_opt = parent_of_node(*m_node);
+    while (parent_opt.has_value()) {
+      const Node &parent = parent_opt.value().get();
+      if (origin_ref > parent.last()) {
+        parent_opt = parent_of_node(parent);
+        continue;
+      }
+
+      for (long idx = 0; idx < parent.numfilled(); ++idx)
+        if (origin_ref < parent.at(idx))
+          return std::make_optional(
+              Iterator{const_cast<Node &>(parent), idx, *m_tree});
+
+      // Should be unreachable
+      assert(false);
+    }
+
+    return std::nullopt;
+  }
+
+  std::optional<Iterator> prev_() const noexcept {
+    // Case 1: Get predecessor in a child
+    const long numfilled = m_node->numfilled();
+    if (m_node->is_branch() && m_index > 0) {
+      const Position link_pos = m_node->branch().links_[m_index - 1];
+      Node &link_node = *Node::LinkMap().at(link_pos);
+      return std::make_optional(
+          Iterator{link_node, link_node.numfilled(), *m_tree});
+    }
+
+    // Case 2: Get predecessor in the current node
+    if (m_index > 0)
+      return std::make_optional(Iterator{*m_node, m_index - 1, *m_tree});
+
+    assert(m_index == 0);
+
+    // Case 3: Get predecessor in parent (or the parent's parent)
+    const auto origin_ref = m_node->at(m_index);
+    auto parent_opt = parent_of_node(*m_node);
+    while (parent_opt.has_value()) {
+      const Node &parent = parent_opt.value().get();
+      if (origin_ref < parent.begin()) {
+        parent_opt = parent_of_node(parent);
+        continue;
+      }
+
+      for (long idx = 0; idx < parent.numfilled(); ++idx)
+        if (origin_ref > parent.at(idx))
+          return std::make_optional(
+              Iterator{const_cast<Node &>(parent), idx, *m_tree});
+
+      // Should be unreachable
+      assert(false);
+    }
+
+    return std::nullopt;
+  }
+
+public: // Iterator operations
+  reference operator*() const { return *m_node; }
+
+  pointer operator->() const { return &(operator*()); }
+
+  Iterator &operator++() {
+    if (m_ok)
+      if (const auto next_opt = next_(); next_opt)
+        *this = next_opt.value();
+    return *this;
+  }
+
+  Iterator operator++(int) {
+    auto copy_ = *this;
+    this->operator++();
+    return copy_;
+  }
+
+  Iterator &operator--() {
+    if (m_ok)
+      if (const auto prev_opt = prev_(); prev_opt)
+        *this = prev_opt.value();
+    return *this;
+  }
+
+  Iterator operator--(int) {
+    auto copy_ = *this;
+    this->operator--();
+    return copy_;
+  }
+
+  bool operator<=>(const Iterator &rhs) const noexcept = default;
+
+private:
+  Node *m_node;
+  long m_index;
+  Btree<Config> *m_tree;
+  bool m_ok{false};
+};
+
+static_assert(std::bidirectional_iterator<Btree<DefaultBtreeConfig>::Iterator>);
+
+} // namespace internal::btree
 
 #endif // _EUGENE_BTREE_INCLUDED_

--- a/src/internal/btree/BtreePrinter.h
+++ b/src/internal/btree/BtreePrinter.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <internal/btree/Btree.h>
+
+namespace internal::btree::util {
+
+template<BtreeConfig Config>
+class BtreeYAMLPrinter {
+	using Bt = Btree<Config>;
+	using Node = typename Bt::Node;
+
+public:
+	explicit BtreeYAMLPrinter(const Bt &bt, std::string ofname = "bpt.yml")
+	    : m_ofname{std::move(ofname)}, m_btree{bt}, m_out{m_ofname,
+	                                                      std::ios::out} {}
+
+	void operator()() noexcept { print(); }
+
+	template<typename InputIt>
+	static std::string join(InputIt begin, const InputIt end,
+	                        std::string_view delim) {
+		std::stringstream ss;
+		while (begin < end - 1)
+			ss << *begin++ << delim;
+		ss << *begin;
+		return ss.str();
+	}
+
+	void print_node(const Node *node, unsigned level = 1) noexcept {
+		const std::string indentation(level * 2, ' ');
+		m_out << indentation;
+		if (level > 1)
+			m_out << "- ";
+		if (node->is_branch() || level == 1)
+			m_out << "keys: ";
+		auto [beginning, _] = node->range();
+		const auto actual_end = beginning + node->numfilled();
+		m_out << '[' << join(beginning, actual_end, ", ") << "]\n";
+		if (node->is_branch()) {
+			m_out << indentation << "children: \n";
+			for (const auto link : node->branch().links_)
+				print_node(Node::fetch_node(link), level + 1);
+		}
+	}
+
+	void print() noexcept {
+		m_out << "keys_per_block: " << Node::records_() << '\n';
+		m_out << "tree:\n";
+
+		print_node(&m_btree.m_root);
+	}
+
+private:
+	std::string m_ofname;
+	const Btree<Config> &m_btree;
+	std::ofstream m_out;
+};
+
+}// namespace internal::btree::util

--- a/src/internal/storage/Storage.h
+++ b/src/internal/storage/Storage.h
@@ -1,0 +1,27 @@
+#ifndef _EUGENE_STORAGEDEVICE_INCLUDED_
+#define _EUGENE_STORAGEDEVICE_INCLUDED_
+
+#include <concepts>
+
+#include <external/expected/Expected.h>
+
+namespace internal::storage
+{
+    	using Position = unsigned long int;
+    	static constexpr Position PositionPoison = 0x41CEBEEF;
+    
+	/*
+	* TODO
+	*/
+	template<typename Dev>
+	concept StorageDevice = true;
+
+	struct DefaultStorageDev {
+
+	};
+
+	static_assert(StorageDevice<DefaultStorageDev>, "Default storage device is not a storage device!");
+}
+
+#endif
+

--- a/src/internal/storage/Storage.h
+++ b/src/internal/storage/Storage.h
@@ -1,27 +1,46 @@
-#ifndef _EUGENE_STORAGEDEVICE_INCLUDED_
-#define _EUGENE_STORAGEDEVICE_INCLUDED_
+#pragma once
 
 #include <concepts>
+#include <functional>// std::hash
 
 #include <external/expected/Expected.h>
 
-namespace internal::storage
-{
-    	using Position = unsigned long int;
-    	static constexpr Position PositionPoison = 0x41CEBEEF;
-    
+namespace internal::storage {
+
+class Position {
+public:
+	Position() = default;
+	Position(const Position &) = default;
+
 	/*
-	* TODO
-	*/
-	template<typename Dev>
-	concept StorageDevice = true;
+	 * Intentionally implicit
+	 */
+	Position(long pos) : m_pos{pos}, m_isset{true} {}
+	operator long() { return m_pos; }
 
-	struct DefaultStorageDev {
+	static auto poison() { return Position(); }
 
-	};
+	[[nodiscard]] auto get() const noexcept { return m_pos; }
+	[[nodiscard]] bool is_set() const noexcept { return m_isset; }
 
-	static_assert(StorageDevice<DefaultStorageDev>, "Default storage device is not a storage device!");
-}
+	void set(long pos) noexcept {
+		m_pos = pos;
+		m_isset = true;
+	}
 
-#endif
+	bool operator==(const Position &rhs) const noexcept { return m_pos == rhs.m_pos; }
+	bool operator!=(const Position &rhs) const noexcept { return m_pos != rhs.m_pos; }
 
+private:
+	long m_pos{0x41CEBEEF};
+	bool m_isset{false};
+};
+
+template<typename Dev>
+concept StorageDevice = true;
+
+struct DefaultStorageDev {
+};
+
+static_assert(StorageDevice<DefaultStorageDev>, "Default storage device is not a storage device!");
+}// namespace internal::storage

--- a/src/internal/storage/Storage.h
+++ b/src/internal/storage/Storage.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <concepts>
-#include <functional>// std::hash
+#include <functional>
+#include <string>
 
 #include <external/expected/Expected.h>
 
@@ -30,6 +31,9 @@ public:
 
 	bool operator==(const Position &rhs) const noexcept { return m_pos == rhs.m_pos; }
 	bool operator!=(const Position &rhs) const noexcept { return m_pos != rhs.m_pos; }
+	bool operator==(long rhs) const noexcept { return m_pos == rhs; }
+
+	[[nodiscard]] std::string str() const noexcept { return std::to_string(m_pos); }
 
 private:
 	long m_pos{0x41CEBEEF};

--- a/src/internal/storage/btree/Btree.h
+++ b/src/internal/storage/btree/Btree.h
@@ -620,7 +620,7 @@ public:// Properties
 	}
 
 	const Node &node() const noexcept { return *m_node; }
-	Node &node_mut() noexcept { return *m_node; }
+	[[maybe_unused]] Node &node() noexcept { return *m_node; }
 
 	long index() const noexcept { return m_index; }
 	long &index() noexcept { return m_index; }

--- a/src/internal/storage/btree/Btree.h
+++ b/src/internal/storage/btree/Btree.h
@@ -22,9 +22,6 @@ consteval bool PowerOf2(T num) {
 #define unsafe_ /* marks function as not noexcept */
 
 template<typename T>
-using optional_ref = std::optional<std::reference_wrapper<T>>;
-
-template<typename T>
 using optional_cref = std::optional<std::reference_wrapper<const T>>;
 
 namespace internal::btree {

--- a/src/internal/storage/btree/BtreePrinter.h
+++ b/src/internal/storage/btree/BtreePrinter.h
@@ -13,7 +13,7 @@ namespace internal::btree::util {
 
 template<typename InputIt>
 std::string join(InputIt begin, const InputIt end,
-                        std::string_view delim) {
+                 std::string_view delim) {
 	std::stringstream ss;
 	while (begin < end - 1)
 		ss << *begin++ << delim;
@@ -44,7 +44,7 @@ public:
 		const auto actual_end = beginning + node->numfilled();
 		m_out << '[' << join(beginning, actual_end, ", ") << "]\n";
 		if (node->is_branch()) {
-			m_out << indentation << "children: \n";
+			m_out << indentation << (level > 1 ? "  " : "") << "children: \n";
 			auto links = node->branch().links_;
 			for (auto it = links.begin(); it != links.end() && *it != Position::poison(); ++it) {
 				print_node(&Node::Cache::the().fetch(*it), level + 1);
@@ -53,7 +53,7 @@ public:
 	}
 
 	void print() noexcept {
-		m_out << "keys_per_block: " << Node::num_records_per_node() << '\n';
+		m_out << "keys_per_block: " << Node::num_records_per_node() - 1 << '\n';
 		m_out << "tree:\n";
 
 		print_node(m_btree.m_root);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,10 +14,10 @@ add_test(NAME ItWorks COMMAND test__itworks)
 ############################## Btree
 
 add_executable(test__btree TestBtree.cpp)
-target_link_libraries(test__btree PUBLIC test__main_fun)
+target_link_libraries(test__btree PUBLIC test__main_fun storage)
 add_test(NAME Btree COMMAND test__btree)
 
 ############################## Btree Printer
 
 add_executable(test__btree_printer TestBtreePrinter.cpp)
-target_link_libraries(test__btree_printer PUBLIC btree)
+target_link_libraries(test__btree_printer PUBLIC storage)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,3 +16,8 @@ add_test(NAME ItWorks COMMAND test__itworks)
 add_executable(test__btree TestBtree.cpp)
 target_link_libraries(test__btree PUBLIC test__main_fun)
 add_test(NAME Btree COMMAND test__btree)
+
+############################## Btree Printer
+
+add_executable(test__btree_printer TestBtreePrinter.cpp)
+target_link_libraries(test__btree_printer PUBLIC btree)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,3 +10,9 @@ target_link_libraries(test__main_fun ${TESTS_DEPENDENCIES})
 add_executable(test__itworks TestItWorks.cpp)
 target_link_libraries(test__itworks PUBLIC test__main_fun)
 add_test(NAME ItWorks COMMAND test__itworks)
+
+############################## Btree
+
+add_executable(test__btree TestBtree.cpp)
+target_link_libraries(test__btree PUBLIC test__main_fun)
+add_test(NAME Btree COMMAND test__btree)

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -29,8 +29,7 @@ TEST_CASE("Btree insert", "[btree]") {
 
 	REQUIRE(node_t::num_links_per_branch() - 1 == node_t::num_records_per_node());
 
-	const uint32_t recs = node_t::num_records_per_node();
-	for (const uint32_t index : iota(0) | take(recs)) {
+	for (const uint32_t index : iota(0, 68)) {
 		const config_::Key key = index;
 		const config_::Val val = index + 1;
 		REQUIRE(!bpt.get(key).has_value());

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -1,21 +1,70 @@
 #include <external/catch2/Catch2.h>
 
-#include <internal/storage/Storage.h>
 #include <internal/btree/Btree.h>
+#include <internal/storage/Storage.h>
+
+#include <iostream>
+#include <ranges>
+using namespace std::ranges::views;
 
 using namespace internal::btree;
+using config_ = DefaultBtreeConfig;
+using bt_t = Btree<config_>;
+using node_t = bt_t::Node;
+using it_t = bt_t::Iterator;
 
-TEST_CASE("Btree init", "[btree]") {
-	[[maybe_unused]] Btree bpt{};
-}
+TEST_CASE("Btree init", "[btree]") { [[maybe_unused]] Btree bpt{}; }
 
 TEST_CASE("Btree find", "[btree]") {
-	[[maybe_unused]] Btree bpt{};
-	[[maybe_unused]] auto it1 = bpt.find(13u);
+  bt_t bpt{};
+  auto it1 = bpt.find(13u);
+  REQUIRE(!it1.has_value());
 }
 
 TEST_CASE("Btree insert", "[btree]") {
-	[[maybe_unused]] Btree bpt{};
-	[[maybe_unused]] auto it1 = bpt.insert(13u, 12u);
+  bt_t bpt;
+  REQUIRE(node_t::records_() > 10);
+  REQUIRE(node_t::links_() > 11);
+  REQUIRE(node_t::links_() - 1 == node_t::records_());
+
+  for (const uint32_t index : iota(0) | take(node_t::records_() - 1)) {
+    const config_::Key key = index;
+    const config_::Val val = index + 1;
+
+    REQUIRE(!bpt.get(key).has_value());
+    const auto it = bpt.insert(key, val);
+    const auto end_it = bpt.end();
+    REQUIRE(it != bpt.end());
+    REQUIRE(it->at(index) == key);
+    REQUIRE(it.index() == key);
+    REQUIRE(it.key() == std::make_optional(key));
+    REQUIRE(it.val() == std::make_optional(val));
+    const auto opt = bpt.get(key);
+    REQUIRE(opt.has_value());
+    REQUIRE(opt.value() == val);
+  }
 }
 
+TEST_CASE("Btree iterator", "[btree]") {
+  [[maybe_unused]] Btree bpt{};
+  REQUIRE(bpt.begin() == bpt.end());
+  REQUIRE(bpt.begin()->is_leftmost());
+  REQUIRE(bpt.begin()->is_rightmost());
+  REQUIRE(bpt.begin()->is_root());
+
+  bpt.insert(13u, 19u);
+  REQUIRE(bpt.begin() != bpt.end());
+
+  auto do_checks = [&](node_t &thing) {
+    REQUIRE(thing.numfilled() == 1);
+    REQUIRE(thing.at(0) == 13u);
+    REQUIRE(thing.is_leaf());
+    REQUIRE(thing.leaf().vals_.at(0) == 19u);
+  };
+
+  for (auto &thing : bpt)
+    do_checks(thing);
+
+  for (auto rit = bpt.end(); rit != bpt.begin(); --rit)
+    do_checks(*rit);
+}

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -11,6 +11,11 @@ TEST_CASE("Btree init", "[btree]") {
 
 TEST_CASE("Btree find", "[btree]") {
 	Btree bpt{};
-	auto it = bpt.find(13u);
+	auto it1 = bpt.find(13u);
+}
+
+TEST_CASE("Btree insert", "[btree]") {
+	Btree bpt{};
+	// auto it1 = bpt.insert(13u, 12u);
 }
 

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -1,7 +1,7 @@
 #include <external/catch2/Catch2.h>
 
-#include <internal/btree/Btree.h>
 #include <internal/storage/Storage.h>
+#include <internal/storage/btree/Btree.h>
 
 #include <iostream>
 #include <ranges>
@@ -16,55 +16,54 @@ using it_t = bt_t::Iterator;
 TEST_CASE("Btree init", "[btree]") { [[maybe_unused]] Btree bpt{}; }
 
 TEST_CASE("Btree find", "[btree]") {
-  bt_t bpt{};
-  auto it1 = bpt.find(13u);
-  REQUIRE(!it1.has_value());
+	bt_t bpt{};
+	bpt.prepare_root_for_inmem();
+	auto it1 = bpt.find(13u);
+	REQUIRE(!it1.has_value());
 }
 
 TEST_CASE("Btree insert", "[btree]") {
-  bt_t bpt;
-  REQUIRE(node_t::records_() > 10);
-  REQUIRE(node_t::links_() > 11);
-  REQUIRE(node_t::links_() - 1 == node_t::records_());
+	bt_t bpt;
+	bpt.prepare_root_for_inmem();
 
-  for (const uint32_t index : iota(0) | take(node_t::records_() - 1)) {
-    const config_::Key key = index;
-    const config_::Val val = index + 1;
 
-    REQUIRE(!bpt.get(key).has_value());
-    const auto it = bpt.insert(key, val);
-    const auto end_it = bpt.end();
-    REQUIRE(it != bpt.end());
-    REQUIRE(it->at(index) == key);
-    REQUIRE(it.index() == key);
-    REQUIRE(it.key() == std::make_optional(key));
-    REQUIRE(it.val() == std::make_optional(val));
-    const auto opt = bpt.get(key);
-    REQUIRE(opt.has_value());
-    REQUIRE(opt.value() == val);
-  }
+	REQUIRE(node_t::num_links_per_branch() - 1 == node_t::num_records_per_node());
+
+	const uint32_t recs = node_t::num_records_per_node();
+	for (const uint32_t index : iota(0) | take(recs)) {
+		const config_::Key key = index;
+		const config_::Val val = index + 1;
+		REQUIRE(!bpt.get(key).has_value());
+		const auto it = bpt.insert(key, val);
+		const auto end_it = bpt.end();
+		REQUIRE(it != bpt.end());
+		const auto opt = bpt.get(key);
+		REQUIRE(opt.has_value());
+		REQUIRE(opt.value() == val);
+	}
 }
 
 TEST_CASE("Btree iterator", "[btree]") {
-  [[maybe_unused]] Btree bpt{};
-  REQUIRE(bpt.begin() == bpt.end());
-  REQUIRE(bpt.begin()->is_leftmost());
-  REQUIRE(bpt.begin()->is_rightmost());
-  REQUIRE(bpt.begin()->is_root());
+	Btree bpt{};
+	bpt.prepare_root_for_inmem();
+	REQUIRE(bpt.begin() == bpt.end());
+	REQUIRE(bpt.begin()->is_leftmost());
+	REQUIRE(bpt.begin()->is_rightmost());
+	REQUIRE(bpt.begin()->is_root());
 
-  bpt.insert(13u, 19u);
-  REQUIRE(bpt.begin() != bpt.end());
+	bpt.insert(13u, 19u);
+	REQUIRE(bpt.begin() != bpt.end());
 
-  auto do_checks = [&](node_t &thing) {
-    REQUIRE(thing.numfilled() == 1);
-    REQUIRE(thing.at(0) == 13u);
-    REQUIRE(thing.is_leaf());
-    REQUIRE(thing.leaf().vals_.at(0) == 19u);
-  };
+	auto do_checks = [&](node_t &thing) {
+		REQUIRE(thing.numfilled() == 1);
+		REQUIRE(thing.at(0) == 13u);
+		REQUIRE(thing.is_leaf());
+		REQUIRE(thing.leaf().vals_.at(0) == 19u);
+	};
 
-  for (auto &thing : bpt)
-    do_checks(thing);
+	for (auto &thing : bpt)
+		do_checks(thing);
 
-  for (auto rit = bpt.end(); rit != bpt.begin(); --rit)
-    do_checks(*rit);
+	for (auto rit = bpt.end(); rit != bpt.begin(); --rit)
+		do_checks(*rit);
 }

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -1,0 +1,11 @@
+#include <external/catch2/Catch2.h>
+
+#include <internal/storage/Storage.h>
+#include <internal/btree/Btree.h>
+
+using namespace internal::btree;
+
+TEST_CASE("Btree init", "[btree]") {
+	Btree bpt{};
+}
+

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -9,3 +9,8 @@ TEST_CASE("Btree init", "[btree]") {
 	Btree bpt{};
 }
 
+TEST_CASE("Btree find", "[btree]") {
+	Btree bpt{};
+	auto it = bpt.find(13u);
+}
+

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -16,6 +16,6 @@ TEST_CASE("Btree find", "[btree]") {
 
 TEST_CASE("Btree insert", "[btree]") {
 	Btree bpt{};
-	// auto it1 = bpt.insert(13u, 12u);
+	auto it1 = bpt.insert(13u, 12u);
 }
 

--- a/tests/TestBtree.cpp
+++ b/tests/TestBtree.cpp
@@ -6,16 +6,16 @@
 using namespace internal::btree;
 
 TEST_CASE("Btree init", "[btree]") {
-	Btree bpt{};
+	[[maybe_unused]] Btree bpt{};
 }
 
 TEST_CASE("Btree find", "[btree]") {
-	Btree bpt{};
-	auto it1 = bpt.find(13u);
+	[[maybe_unused]] Btree bpt{};
+	[[maybe_unused]] auto it1 = bpt.find(13u);
 }
 
 TEST_CASE("Btree insert", "[btree]") {
-	Btree bpt{};
-	auto it1 = bpt.insert(13u, 12u);
+	[[maybe_unused]] Btree bpt{};
+	[[maybe_unused]] auto it1 = bpt.insert(13u, 12u);
 }
 

--- a/tests/TestBtreePrinter.cpp
+++ b/tests/TestBtreePrinter.cpp
@@ -1,5 +1,5 @@
-#include <internal/btree/Btree.h>
-#include <internal/btree/BtreePrinter.h>
+#include <internal/storage/btree/Btree.h>
+#include <internal/storage/btree/BtreePrinter.h>
 
 #include <iostream>
 #include <ranges>
@@ -16,16 +16,20 @@ using it_t = bt_t::Iterator;
 
 // Btree Print Single Layer
 int main() {
-  bt_t bpt;
+	bt_t bpt;
+	bpt.prepare_root_for_inmem();
 
-//  for (const uint32_t index : iota(0) | take(node_t::records_())) {
-  for (const uint32_t index : iota(0, 10)) {
-    const config_::Key key = index;
-    const config_::Val val = index + 1;
+	for (const uint32_t index : iota(0) | take(node_t::num_records_per_node())) {
+		const config_::Key key = index;
+		const config_::Val val = index + 1;
 
-    [[maybe_unused]] const auto it = bpt.insert(key, val);
-  }
+		[[maybe_unused]] const auto it = bpt.insert(key, val);
+		if (!bpt.get(key)) {
+			std::cerr << "failed when looking for inserted key = " << key << '\n';
+			return -1;
+		}
+	}
 
-  btprinter_t printer{bpt};
-  printer.print();
+	btprinter_t printer{bpt};
+	printer.print();
 }

--- a/tests/TestBtreePrinter.cpp
+++ b/tests/TestBtreePrinter.cpp
@@ -1,0 +1,31 @@
+#include <internal/btree/Btree.h>
+#include <internal/btree/BtreePrinter.h>
+
+#include <iostream>
+#include <ranges>
+using namespace std::ranges::views;
+
+using namespace internal::btree;
+using namespace internal::btree::util;
+
+using config_ = DefaultBtreeConfig;
+using bt_t = Btree<config_>;
+using btprinter_t = BtreeYAMLPrinter<config_>;
+using node_t = bt_t::Node;
+using it_t = bt_t::Iterator;
+
+// Btree Print Single Layer
+int main() {
+  bt_t bpt;
+
+//  for (const uint32_t index : iota(0) | take(node_t::records_())) {
+  for (const uint32_t index : iota(0, 10)) {
+    const config_::Key key = index;
+    const config_::Val val = index + 1;
+
+    [[maybe_unused]] const auto it = bpt.insert(key, val);
+  }
+
+  btprinter_t printer{bpt};
+  printer.print();
+}


### PR DESCRIPTION
# Description

Provides implementation of the core functionality related to the b-tree data structure placed in the lowest-layer.

# Demo:
![image](https://user-images.githubusercontent.com/36764968/140422240-f65176bf-33e2-4259-8641-ca275887a8f9.png)

# Testing

The implementation comes in combination with a couple of tests placed under `tests/`.

# Environment

* OS: `Archcraft, Linux 5.14.15-arch1-1, x86-64`
* Compiler: `gcc 11.1.0`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes