### PR TITLE
Implement pager as a "storage driver"

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(STORAGE_SOURCES Position.h Page.h Storage.h btree/Btree.h btree/BtreePrinter.h
+set(STORAGE_SOURCES Position.h PageCache.h Page.h Storage.h btree/Btree.h btree/BtreePrinter.h
                     compression/Compressor.h compression/Decompressor.h)
 
 list(TRANSFORM STORAGE_SOURCES PREPEND "storage/")
@@ -28,4 +28,8 @@ if(DEFINED ENV{EUGENE_BUILD_TESTS})
   add_executable(test_page storage/Page.h storage/Page.cpp)
   target_link_libraries(test_page PUBLIC test_main)
   add_test(NAME TestPage COMMAND test_page)
+
+  add_executable(test_pgcache storage/PageCache.h storage/PageCache.cpp)
+  target_link_libraries(test_pgcache PUBLIC test_main)
+  add_test(NAME TestPageCache COMMAND test_pgcache)
 endif()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,4 +27,8 @@ if(DEFINED ENV{EUGENE_BUILD_TESTS})
   add_executable(test_btree storage/btree/Btree.cpp)
   target_link_libraries(test_btree PUBLIC test_main storage)
   add_test(NAME TestBtree COMMAND test_btree)
+
+  add_executable(test_page storage/Page.h storage/Page.cpp)
+  target_link_libraries(test_page PUBLIC test_main)
+  add_test(NAME TestPage COMMAND test_page)
 endif()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(STORAGE_SOURCES Position.h PageCache.h Page.h Storage.h btree/Btree.h btree/BtreePrinter.h
-                    compression/Compressor.h compression/Decompressor.h)
+	compression/Compressor.h compression/Decompressor.h btree/Btree.cpp compression/TestCompressorDecompressor.cpp
+	PageCache.cpp Page.cpp)
 
 list(TRANSFORM STORAGE_SOURCES PREPEND "storage/")
 add_library(storage "${STORAGE_SOURCES}")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,10 +1,7 @@
-set(BTREE_SOURCES btree/Btree.h btree/BtreePrinter.h)
+set(STORAGE_SOURCES Position.h Page.h Storage.h btree/Btree.h btree/BtreePrinter.h
+                    compression/Compressor.h compression/Decompressor.h)
 
-set(COMPR_SOURCE compression/Compressor.h compression/Decompressor.h)
-
-set(STORAGE_SOURCES Storage.h "${BTREE_SOURCE}" "${COMPR_SOURCE}")
 list(TRANSFORM STORAGE_SOURCES PREPEND "storage/")
-
 add_library(storage "${STORAGE_SOURCES}")
 add_eugene_internal_lib(storage)
 

--- a/src/core/storage/Page.cpp
+++ b/src/core/storage/Page.cpp
@@ -1,0 +1,23 @@
+#include <algorithm>
+
+#include <third-party/catch2/Catch2.h>
+
+#include <core/storage/Page.h>
+
+using namespace internal::storage;
+
+TEST_CASE("Page", "[page]") {
+	Pager pr("/tmp/page-test-disk");
+
+	std::array<uint8_t, PAGE_SIZE> p1_data;
+	std::iota(p1_data.begin(), p1_data.end(), 1);
+	Page p1(std::move(p1_data));
+	REQUIRE(pr.sync(p1) == 0l);
+
+	std::array<uint8_t, PAGE_SIZE> p2_data;
+	std::iota(p2_data.begin(), p2_data.end(), 2);
+	Page p2(std::move(p2_data));
+	REQUIRE(pr.sync(p2) == (long)PAGE_SIZE);
+
+	REQUIRE(pr.fetch(p2, 0) == p1);
+}

--- a/src/core/storage/Page.cpp
+++ b/src/core/storage/Page.cpp
@@ -7,17 +7,53 @@
 using namespace internal::storage;
 
 TEST_CASE("Page", "[page]") {
-	Pager pr("/tmp/page-test-disk");
+	Pager pr("/tmp/eu-pager");
 
-	std::array<uint8_t, PAGE_SIZE> p1_data;
+	std::array<uint8_t, Page::size()> p1_data;
 	std::iota(p1_data.begin(), p1_data.end(), 1);
 	Page p1(std::move(p1_data));
 	REQUIRE(pr.sync(p1) == 0l);
 
-	std::array<uint8_t, PAGE_SIZE> p2_data;
+	auto p2_pos = pr.alloc();
+	REQUIRE((long) p2_pos == Page::size());
+
+	std::array<uint8_t, Page::size()> p3_data;
+	std::iota(p3_data.begin(), p3_data.end(), 3);
+	Page p3(std::move(p3_data));
+	REQUIRE(pr.sync(p3) == 2l * Page::size());
+
+	std::array<uint8_t, Page::size()> p2_data;
 	std::iota(p2_data.begin(), p2_data.end(), 2);
 	Page p2(std::move(p2_data));
-	REQUIRE(pr.sync(p2) == (long)PAGE_SIZE);
+	REQUIRE(pr.sync(p2, p2_pos) == (long) p2_pos);
 
-	REQUIRE(pr.fetch(p2, 0) == p1);
+	pr.fetch(p3, 0);
+	REQUIRE(p3 == p1);
+	pr.fetch(p3, p2_pos);
+	REQUIRE(p3 == p2);
+}
+
+TEST_CASE("Page operations", "[page]") {
+	std::array<uint8_t, Page::size()> p_data;
+	std::fill(p_data.begin(), p_data.end(), 1);
+	Page p(std::move(p_data));
+
+	auto [d1_begin, d1_end] = p.read(10, 5).value();
+	std::array<uint8_t, 5> d1_expected { 1 };
+	std::fill(d1_expected.begin(), d1_expected.end(), 1);
+	REQUIRE(std::distance(d1_begin, d1_end) == 5);
+	REQUIRE(std::equal(d1_begin, d1_end, d1_expected.cbegin()));
+
+	for (std::size_t i = 0; i < Page::size(); ++i) {
+		auto d2 = p.read(i).value();
+		REQUIRE(d2 == 1);
+	}
+
+	std::array<uint8_t, 10> d3;
+	std::iota(d3.begin(), d3.end(), 1);
+	p.write(100, d3.cbegin(), d3.cend());
+	auto [d3_begin, d3_end] = p.read(100, 10).value();
+	REQUIRE(std::equal(d3_begin, d3_end, d3.cbegin()));
+
+	REQUIRE(!p.read(Page::size(), 1).has_value());
 }

--- a/src/core/storage/Page.h
+++ b/src/core/storage/Page.h
@@ -1,74 +1,127 @@
 #pragma once
 
 #include <array>
+#include <cassert>
+#include <concepts>
 #include <fstream>
 #include <optional>
-#include <span>
 #include <string_view>
-#include <cassert>
 
 #include <core/storage/Position.h>
 
 namespace internal::storage {
 
-static constexpr int32_t PAGE_SIZE = 1 << 14;
+class Pager;
 
+//!
+//! Single "addressable" unit used by the Pager
+//!
 class Page {
+	static inline constexpr int32_t SIZE = 1 << 14;
+
+	friend Pager;
+
 public:
-	explicit Page(std::array<uint8_t, PAGE_SIZE> &&data)
-	    : m_data{std::move(data)} {}
+	explicit Page(std::array<uint8_t, Page::SIZE> &&data, bool used = true)
+	    : m_data{std::move(data)}, m_used{used} {}
 
-	void write_byte_at(Position pos, int32_t data) noexcept {
-		if (pos > (long) (PAGE_SIZE - sizeof(uint32_t)))
+	Page(const Page &) = default;
+	Page(Page &&) = default;
+
+	Page &operator=(const Page &) noexcept = default;
+	Page &operator=(Page &&) noexcept = default;
+
+	using data_iterator = std::array<uint8_t, Page::SIZE>::iterator;
+	using data_citerator = std::array<uint8_t, Page::SIZE>::const_iterator;
+
+	static Page empty() noexcept {
+		std::array<uint8_t, Page::SIZE> a{0};
+		return Page{std::move(a), false};
+	}
+
+	void write(Position pos, int8_t d) noexcept {
+		if (pos + 1 > (long) size())
 			return;
-		for (int i = 0; i < 4; ++i)
-			m_data[pos + i] = (data | (0xff << i));
+		*(raw() + pos) = d;
+		m_dirty = true;
 	}
 
-	std::optional<uint32_t> read_byte_from(Position pos) noexcept {
-		if (pos > (long) (PAGE_SIZE - sizeof(uint32_t)))
+	void write(Position pos, data_citerator data_begin, data_citerator data_end) noexcept {
+		auto numbytes = std::distance(data_begin, data_end);
+		if (pos + numbytes > size())
+			return;
+		for (unsigned i = 0; i < numbytes; ++i)
+			*(raw() + pos + i) = *(data_begin + i);
+		m_dirty = true;
+	}
+
+	std::optional<uint8_t> read(Position pos) noexcept {
+		if (pos + 1 > (long) size())
 			return {};
-
-		uint8_t *bytes = m_data.data() + pos;
-		return bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
+		return *(raw() + pos);
 	}
 
-	std::optional<std::span<uint8_t>> read_bytes_from(Position pos, uint32_t size) noexcept {
-		if (pos > (long) (PAGE_SIZE - sizeof(uint32_t) * size))
-			return {};
-		return std::span{m_data.begin() + pos, size};
+	std::optional<std::pair<data_citerator, data_citerator>> read(Position pos, uint32_t numbytes) noexcept {
+		if (pos + numbytes > size())
+			return std::nullopt;
+		auto it_begin = m_data.cbegin() + pos;
+		auto it_end = m_data.cbegin() + pos + numbytes;
+		return std::make_pair(it_begin, it_end);
 	}
 
-	[[nodiscard]] const uint8_t *data() const noexcept { return m_data.data(); }
+	[[nodiscard]] auto operator<=>(const Page &) const = default;
 
-	[[nodiscard]] auto operator<=>(const Page&) const = default;
+public:
+	[[nodiscard]] uint8_t *raw() noexcept { return m_data.data(); }
+
+	[[nodiscard]] const uint8_t *raw() const noexcept { return m_data.data(); }
+
+	[[nodiscard]] std::array<uint8_t, Page::SIZE> &get() noexcept { return m_data; }
+
+	[[nodiscard]] bool used() const noexcept { return m_used; }
+
+	[[nodiscard]] bool dirty() const noexcept { return m_dirty; }
+
+	[[nodiscard]] static constexpr uint32_t size() noexcept { return Page::SIZE; }
 
 private:
-	std::array<uint8_t, PAGE_SIZE> m_data;
+	std::array<uint8_t, Page::SIZE> m_data;
+	bool m_used = false;
+	bool m_dirty = false;
 };
 
+//!
+//! "Storage driver"
+//! Responsible for managing low-level storage access
+//! a.k.a the one doing the actual read()'s and write()'s
 class Pager {
 public:
 	explicit Pager(std::string_view fname)
 	    : m_cursor{0},
 	      m_file{fname.data(), std::ios::in | std::ios::out | std::ios::trunc},
-		  m_filename{fname} {
-			  assert(m_file);
-		  }
+	      m_filename{fname} {
+		assert(m_file);
+	}
 
 	Position sync(const Page &page, std::optional<Position> pos_opt = {}) noexcept {
 		Position sync_pos = pos_opt.value_or(m_cursor);
 		m_file.seekp((long) sync_pos);
-		m_file.write(reinterpret_cast<const char *>(page.data()), PAGE_SIZE);
+		m_file.write(reinterpret_cast<const char *>(page.raw()), Page::size());
 		if (!pos_opt)
-			m_cursor += PAGE_SIZE;
+			m_cursor += Page::size();
 		return sync_pos;
 	}
 
 	Page &fetch(Page &page, Position pos) noexcept {
 		m_file.seekp((long) pos);
-		m_file.read(reinterpret_cast<char *>(&page), PAGE_SIZE);
+		m_file.read(reinterpret_cast<char *>(&page), Page::size());
 		return page;
+	}
+
+	Position alloc() noexcept {
+		auto tmp = m_cursor;
+		m_cursor += Page::size();
+		return tmp;
 	}
 
 private:

--- a/src/core/storage/Page.h
+++ b/src/core/storage/Page.h
@@ -31,7 +31,6 @@ public:
 	Page &operator=(const Page &) noexcept = default;
 	Page &operator=(Page &&) noexcept = default;
 
-	using data_iterator = std::array<uint8_t, Page::SIZE>::iterator;
 	using data_citerator = std::array<uint8_t, Page::SIZE>::const_iterator;
 
 	static Page empty() noexcept {

--- a/src/core/storage/Page.h
+++ b/src/core/storage/Page.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <array>
+#include <fstream>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <cassert>
+
+#include <core/storage/Position.h>
+
+namespace internal::storage {
+
+static constexpr int32_t PAGE_SIZE = 1 << 14;
+
+class Page {
+public:
+	explicit Page(std::array<uint8_t, PAGE_SIZE> &&data)
+	    : m_data{std::move(data)} {}
+
+	void write_byte_at(Position pos, int32_t data) noexcept {
+		if (pos > (long) (PAGE_SIZE - sizeof(uint32_t)))
+			return;
+		for (int i = 0; i < 4; ++i)
+			m_data[pos + i] = (data | (0xff << i));
+	}
+
+	std::optional<uint32_t> read_byte_from(Position pos) noexcept {
+		if (pos > (long) (PAGE_SIZE - sizeof(uint32_t)))
+			return {};
+
+		uint8_t *bytes = m_data.data() + pos;
+		return bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
+	}
+
+	std::optional<std::span<uint8_t>> read_bytes_from(Position pos, uint32_t size) noexcept {
+		if (pos > (long) (PAGE_SIZE - sizeof(uint32_t) * size))
+			return {};
+		return std::span{m_data.begin() + pos, size};
+	}
+
+	[[nodiscard]] const uint8_t *data() const noexcept { return m_data.data(); }
+
+	[[nodiscard]] auto operator<=>(const Page&) const = default;
+
+private:
+	std::array<uint8_t, PAGE_SIZE> m_data;
+};
+
+class Pager {
+public:
+	explicit Pager(std::string_view fname)
+	    : m_cursor{0},
+	      m_file{fname.data(), std::ios::in | std::ios::out | std::ios::trunc},
+		  m_filename{fname} {
+			  assert(m_file);
+		  }
+
+	Position sync(const Page &page, std::optional<Position> pos_opt = {}) noexcept {
+		Position sync_pos = pos_opt.value_or(m_cursor);
+		m_file.seekp((long) sync_pos);
+		m_file.write(reinterpret_cast<const char *>(page.data()), PAGE_SIZE);
+		if (!pos_opt)
+			m_cursor += PAGE_SIZE;
+		return sync_pos;
+	}
+
+	Page &fetch(Page &page, Position pos) noexcept {
+		m_file.seekp((long) pos);
+		m_file.read(reinterpret_cast<char *>(&page), PAGE_SIZE);
+		return page;
+	}
+
+private:
+	long m_cursor;
+	std::fstream m_file;
+	std::string_view m_filename;
+};
+
+}// namespace internal::storage

--- a/src/core/storage/PageCache.cpp
+++ b/src/core/storage/PageCache.cpp
@@ -1,0 +1,63 @@
+#include <algorithm>
+#include <array>
+#include <fstream>
+#include <filesystem>
+
+#include <third-party/catch2/Catch2.h>
+
+#include <core/storage/PageCache.h>
+#include <core/storage/Page.h>
+#include <core/storage/Position.h>
+
+using namespace internal::storage;
+
+static constexpr std::string_view test_output_fname = "/tmp/eu-bufpool-test1";
+static constexpr std::size_t test_num_pages = 3;
+
+TEST_CASE("buffer-pool-ops", "[bufpool]") {
+	PageCache pgcache(test_output_fname, PageCache::min_size());
+	REQUIRE(!pgcache.full());
+
+	std::array<uint8_t, Page::size()> data;
+	auto make_dirty_page = [&, val = 0]() mutable {
+		auto p = Page::empty();
+		std::fill(data.begin(), data.end(), val++);
+		p.write(0, data.cbegin(), data.cend());
+
+		auto pos = pgcache.get_new_pos();
+		// Don't copy in order to be able to compare read page later
+		pgcache.put_page(pos, Page(p));
+		REQUIRE(pgcache.get_page(pos) == p);
+
+		auto &cpage = pgcache.get_page(pos);
+		std::fill(data.begin(), data.end(), val++);
+		cpage.write(0, data.cbegin(), data.cend());
+		pgcache.put_page(pos, Page(cpage));
+		REQUIRE(cpage == pgcache.get_page(pos));
+	};
+
+	for (size_t i = 0; i < test_num_pages; ++i) {
+		make_dirty_page();
+		REQUIRE(pgcache.full());
+	}
+
+	pgcache.flush_all();
+
+	char *ptr = reinterpret_cast<char *>(const_cast<unsigned char *>(data.data()));
+
+	REQUIRE(std::filesystem::file_size("/tmp/eu-bufpool-test1") == test_num_pages * Page::size());
+
+	std::fstream fbufpool("/tmp/eu-bufpool-test1", std::ios::in);
+	fbufpool.seekg(fbufpool.beg);
+
+	auto value_of_page = [](int i) {
+		return i * 2 + 1;
+	};
+
+	for (std::size_t i = 0; i < test_num_pages; ++i) {
+		fbufpool.seekg(i * Page::size());
+		fbufpool.read(ptr, Page::size());
+		for (std::size_t j = 0; j < Page::size(); ++j)
+			REQUIRE(ptr[j] == value_of_page(i));
+	}
+}

--- a/src/core/storage/PageCache.cpp
+++ b/src/core/storage/PageCache.cpp
@@ -48,7 +48,7 @@ TEST_CASE("buffer-pool-ops", "[bufpool]") {
 	REQUIRE(std::filesystem::file_size("/tmp/eu-bufpool-test1") == test_num_pages * Page::size());
 
 	std::fstream fbufpool("/tmp/eu-bufpool-test1", std::ios::in);
-	fbufpool.seekg(fbufpool.beg);
+	fbufpool.seekg(std::fstream::beg);
 
 	auto value_of_page = [](int i) {
 		return i * 2 + 1;

--- a/src/core/storage/PageCache.h
+++ b/src/core/storage/PageCache.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <algorithm>
 #include <list>
 #include <unordered_map>
 #include <utility>

--- a/src/core/storage/PageCache.h
+++ b/src/core/storage/PageCache.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include <algorithm>
+#include <list>
+#include <unordered_map>
+#include <utility>
+
+#include <third-party/expected/Expected.h>
+
+#include <core/storage/Page.h>
+#include <core/storage/Position.h>
+
+static constexpr uint32_t operator""_MB(const unsigned long long x) {
+	return x * 1 << 20;
+}
+
+namespace internal::storage {
+
+//! Buffer pool structure.
+//! Implemented as a write-behind LRU cache.
+//! Controls access to pages using an internal pager.
+class PageCache {
+	using PosPage = std::pair<Position, Page>;
+
+private:
+	void evict_lru() {
+		// This cache implementation is write-behind so this is the stage at which
+		// dirty pages are synced with the disc
+		auto &[pos, page] = m_pool.back();
+		if (page.dirty())
+			m_pager.sync(page, pos);
+
+		m_index.erase(pos);
+		m_pool.pop_back();
+	}
+
+public:
+	template<typename String>
+	explicit PageCache(String &&pager_fname, uint32_t size = 1_MB)
+	    : m_size{size},
+	      m_limit{size / sizeof(PosPage)},
+	      m_pager{std::forward<String>(pager_fname)} {
+		assert(size >= sizeof(PosPage));
+		assert(m_limit > 0);
+	}
+
+	/*
+	 * Acquire a reference to a page loaded inside the buffer pool.
+	 * If the desired page is not originally present in the index,
+	 * it is added using the put_page() mechanism.
+	 */
+	Page &get_page(Position page_pos) {
+		auto it = m_index.find(page_pos);
+		if (it == m_index.end()) {
+			Page tmp_clone = m_pager.fetch(m_tmp, page_pos);
+			put_page(page_pos, std::move(tmp_clone));
+			it = m_index.find(page_pos);
+			assert(it != m_index.end());
+		}
+		m_pool.splice(m_pool.begin(), m_pool, it->second);
+		return it->second->second;
+	}
+
+	/*
+	 * Place *owned* page inside the buffer pool.
+	 * If not space is currently available, the
+	 * least recently used page is evicted.
+	 */
+	void put_page(Position page_pos, Page &&page) {
+		if (auto it = m_index.find(page_pos); it != m_index.end()) {
+			m_index[page_pos]->second = std::move(page);
+			return;
+		}
+
+		if (full())
+			evict_lru();
+
+		// From this point on the cache *owns* this page
+		m_pool.emplace_front(page_pos, std::move(page));
+		m_index.emplace(page_pos, m_pool.begin());
+	}
+
+	void flush_all() {
+		while (!empty())
+			evict_lru();
+	}
+
+	[[nodiscard]] Position get_new_pos() noexcept { return m_pager.alloc(); }
+
+	[[nodiscard]] bool full() const noexcept { return m_index.size() == m_limit; }
+
+	[[nodiscard]] bool empty() const noexcept { return m_index.size() == 0; }
+
+	[[nodiscard]] uint32_t static constexpr min_size() noexcept { return sizeof(PosPage); }
+
+private:
+	const std::size_t m_size;
+	const std::size_t m_limit;
+
+	std::list<PosPage> m_pool;
+	std::unordered_map<Position, decltype(m_pool)::iterator> m_index;
+
+	Page m_tmp{{0}};
+
+	Pager m_pager;
+};
+
+}// namespace internal::storage

--- a/src/core/storage/Position.h
+++ b/src/core/storage/Position.h
@@ -1,15 +1,17 @@
 #pragma once
 
+#include <functional>
 #include <string>
 
 namespace internal::storage {
 
 class Position {
+	friend std::hash<Position>;
 public:
 	Position() = default;
 	Position(const Position &) = default;
 
-	Position& operator=(const Position &) = default;
+	Position &operator=(const Position &) = default;
 
 	/*
 	 * Intentionally implicit
@@ -39,3 +41,16 @@ private:
 };
 
 }// namespace internal::storage
+
+
+/*
+ * Implement std::hash<> for Position
+ */
+namespace std {
+	template <>
+	struct hash<internal::storage::Position> {
+		size_t operator() (const internal::storage::Position pos) const noexcept {
+			return std::hash<decltype(pos.m_pos)>{}(pos.m_pos);
+		}
+	};
+}

--- a/src/core/storage/Position.h
+++ b/src/core/storage/Position.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+
+namespace internal::storage {
+
+class Position {
+public:
+	Position() = default;
+	Position(const Position &) = default;
+
+	Position& operator=(const Position &) = default;
+
+	/*
+	 * Intentionally implicit
+	 */
+	Position(long pos) : m_pos{pos}, m_isset{true} {}
+	operator long() { return m_pos; }
+
+	static auto poison() { return Position(); }
+
+	[[nodiscard]] auto get() const noexcept { return m_pos; }
+	[[nodiscard]] bool is_set() const noexcept { return m_isset; }
+
+	void set(long pos) noexcept {
+		m_pos = pos;
+		m_isset = true;
+	}
+
+	bool operator==(const Position &rhs) const noexcept { return m_pos == rhs.m_pos; }
+	bool operator!=(const Position &rhs) const noexcept { return m_pos != rhs.m_pos; }
+	bool operator==(long rhs) const noexcept { return m_pos == rhs; }
+
+	[[nodiscard]] std::string str() const noexcept { return std::to_string(m_pos); }
+
+private:
+	long m_pos{0x41CEBEEF};
+	bool m_isset{false};
+};
+
+}// namespace internal::storage


### PR DESCRIPTION
# Description
Add components responsible for managing low-level file access:

- the `Pager` reads and writes to files based on (`Page.h`)
- `Page`s which are the smallest unit accessible to the `Pager` (`Page.h`)
- the `PageCache` optimizes disk access using an LRU write-behind policy. (`PageCache.h`)

# Test suite

For `Page` (`Page.cpp`):
- Creates a page and performs various operations on it: reading data, writing a different one, comparing, fetched bytes, etc.

For `PageCache` (`PageCache.cpp`):
- Creates a cache of small size and tries to put more pages than possible in it. Page contents are modified in order to mark them as dirty and sync the disk versions with the memory ones.
- At the end the actual file contents are compared with the expected values.

# Environment
Using `gcc (GCC) 11.1.0` on a `x86_64` machine with `GNU/Linux`.

--------------------

#### This PR makes changes which ...

- [x] are thoroughly tested
- [ ] are well documented
